### PR TITLE
Update Russian translation

### DIFF
--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -33,7 +33,7 @@
     <string name="remove_from_playlist">Удалить из плейлиста</string>
     <string name="remove_from_playlist_description">Композиции будут удалены только из плейлиста «%1$s», сами файлы удалены не будут.</string>
     <string name="delete_the_files_too">Удалить файлы тоже</string>
-    <string name="open_playlist">Open playlist</string>
+    <string name="open_playlist">Открыть плейлист</string>
     <string name="initial_playlist">Начальный плейлист</string>
     <string name="initial_playlist_cannot_be_deleted">Начальный плейлист не может быть удалён</string>
     <string name="empty_playlist">Текущий плейлист пуст</string>


### PR DESCRIPTION
I've missed one string yesterday, so here's another update.

I use a local weblate instance to translate things, and it usually marks strings that have translation == source, but this one it didn't. Weird.