### PR TITLE
Set contentDescriptions for navigation buttons.

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/activities/MainActivity.kt
@@ -143,6 +143,7 @@ class MainActivity : SimpleActivity(), SongListListener {
         }
 
         setupIconColors()
+        setupIconDescriptions()
         markCurrentSong()
         updateTextColors(main_holder)
         getSongsAdapter()?.updateColors()
@@ -315,6 +316,7 @@ class MainActivity : SimpleActivity(), SongListListener {
         config.isShuffleEnabled = isShuffleEnabled
         shuffle_btn.applyColorFilter(if (isShuffleEnabled) getAdjustedPrimaryColor() else config.textColor)
         shuffle_btn.alpha = if (isShuffleEnabled) 1f else LOWER_ALPHA
+        shuffle_btn.contentDescription = resources.getString(if (isShuffleEnabled) R.string.disable_shuffle else R.string.enable_shuffle)
         getSongsAdapter()?.updateShuffle(isShuffleEnabled)
         toast(if (isShuffleEnabled) R.string.shuffle_enabled else R.string.shuffle_disabled)
     }
@@ -324,6 +326,7 @@ class MainActivity : SimpleActivity(), SongListListener {
         config.repeatSong = repeatSong
         repeat_btn.applyColorFilter(if (repeatSong) getAdjustedPrimaryColor() else config.textColor)
         repeat_btn.alpha = if (repeatSong) 1f else LOWER_ALPHA
+        repeat_btn.contentDescription = resources.getString(if (repeatSong) R.string.disable_song_repetition else R.string.enable_song_repetition)
         getSongsAdapter()?.updateRepeatSong(repeatSong)
         toast(if (repeatSong) R.string.song_repetition_enabled else R.string.song_repetition_disabled)
     }
@@ -519,8 +522,14 @@ class MainActivity : SimpleActivity(), SongListListener {
         songs_fastscroller.updatePrimaryColor()
     }
 
+    private fun setupIconDescriptions() {
+        shuffle_btn.contentDescription = resources.getString(if (config.isShuffleEnabled) R.string.disable_shuffle else R.string.enable_shuffle)
+        repeat_btn.contentDescription = resources.getString(if (config.repeatSong) R.string.disable_song_repetition else R.string.enable_song_repetition)
+    }
+
     private fun songPicked(pos: Int) {
         setupIconColors()
+        setupIconDescriptions()
         Intent(this, MusicService::class.java).apply {
             putExtra(SONG_POS, pos)
             action = PLAYPOS

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/activities/MainActivity.kt
@@ -316,7 +316,7 @@ class MainActivity : SimpleActivity(), SongListListener {
         config.isShuffleEnabled = isShuffleEnabled
         shuffle_btn.applyColorFilter(if (isShuffleEnabled) getAdjustedPrimaryColor() else config.textColor)
         shuffle_btn.alpha = if (isShuffleEnabled) 1f else LOWER_ALPHA
-        shuffle_btn.contentDescription = resources.getString(if (isShuffleEnabled) R.string.disable_shuffle else R.string.enable_shuffle)
+        shuffle_btn.contentDescription = getString(if (isShuffleEnabled) R.string.disable_shuffle else R.string.enable_shuffle)
         getSongsAdapter()?.updateShuffle(isShuffleEnabled)
         toast(if (isShuffleEnabled) R.string.shuffle_enabled else R.string.shuffle_disabled)
     }
@@ -326,7 +326,7 @@ class MainActivity : SimpleActivity(), SongListListener {
         config.repeatSong = repeatSong
         repeat_btn.applyColorFilter(if (repeatSong) getAdjustedPrimaryColor() else config.textColor)
         repeat_btn.alpha = if (repeatSong) 1f else LOWER_ALPHA
-        repeat_btn.contentDescription = resources.getString(if (repeatSong) R.string.disable_song_repetition else R.string.enable_song_repetition)
+        repeat_btn.contentDescription = getString(if (repeatSong) R.string.disable_song_repetition else R.string.enable_song_repetition)
         getSongsAdapter()?.updateRepeatSong(repeatSong)
         toast(if (repeatSong) R.string.song_repetition_enabled else R.string.song_repetition_disabled)
     }
@@ -523,8 +523,8 @@ class MainActivity : SimpleActivity(), SongListListener {
     }
 
     private fun setupIconDescriptions() {
-        shuffle_btn.contentDescription = resources.getString(if (config.isShuffleEnabled) R.string.disable_shuffle else R.string.enable_shuffle)
-        repeat_btn.contentDescription = resources.getString(if (config.repeatSong) R.string.disable_song_repetition else R.string.enable_song_repetition)
+        shuffle_btn.contentDescription = getString(if (config.isShuffleEnabled) R.string.disable_shuffle else R.string.enable_shuffle)
+        repeat_btn.contentDescription = getString(if (config.repeatSong) R.string.disable_song_repetition else R.string.enable_song_repetition)
     }
 
     private fun songPicked(pos: Int) {

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/adapters/SongAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/adapters/SongAdapter.kt
@@ -447,6 +447,7 @@ class SongAdapter(activity: SimpleActivity, var songs: ArrayList<Song>, val list
         navigationView?.apply {
             shuffle_btn.applyColorFilter(if (enable) adjustedPrimaryColor else textColor)
             shuffle_btn.alpha = if (enable) 1f else LOWER_ALPHA
+            shuffle_btn.contentDescription = resources.getString(if (enable) R.string.disable_shuffle else R.string.enable_shuffle)
         }
     }
 
@@ -454,6 +455,7 @@ class SongAdapter(activity: SimpleActivity, var songs: ArrayList<Song>, val list
         navigationView?.apply {
             repeat_btn.applyColorFilter(if (repeat) adjustedPrimaryColor else textColor)
             repeat_btn.alpha = if (repeat) 1f else LOWER_ALPHA
+            repeat_btn.contentDescription = resources.getString(if (repeat) R.string.disable_song_repetition else R.string.enable_song_repetition)
         }
     }
 

--- a/app/src/main/res/layout/item_navigation.xml
+++ b/app/src/main/res/layout/item_navigation.xml
@@ -48,7 +48,8 @@
             android:background="?attr/selectableItemBackgroundBorderless"
             android:paddingTop="@dimen/small_margin"
             android:paddingBottom="@dimen/small_margin"
-            android:src="@drawable/ic_shuffle"/>
+            android:src="@drawable/ic_shuffle"
+            android:contentDescription="@string/enable_shuffle"/>
 
         <ImageView
             android:id="@+id/previous_btn"
@@ -58,7 +59,8 @@
             android:background="?attr/selectableItemBackgroundBorderless"
             android:paddingTop="@dimen/small_margin"
             android:paddingBottom="@dimen/small_margin"
-            android:src="@drawable/ic_previous"/>
+            android:src="@drawable/ic_previous"
+            android:contentDescription="@string/previous"/>
 
         <ImageView
             android:id="@+id/play_pause_btn"
@@ -68,7 +70,8 @@
             android:background="?attr/selectableItemBackgroundBorderless"
             android:paddingTop="@dimen/small_margin"
             android:paddingBottom="@dimen/small_margin"
-            android:src="@drawable/ic_play"/>
+            android:src="@drawable/ic_play"
+            android:contentDescription="@string/playpause"/>
 
         <ImageView
             android:id="@+id/next_btn"
@@ -78,7 +81,8 @@
             android:background="?attr/selectableItemBackgroundBorderless"
             android:paddingTop="@dimen/small_margin"
             android:paddingBottom="@dimen/small_margin"
-            android:src="@drawable/ic_next"/>
+            android:src="@drawable/ic_next"
+            android:contentDescription="@string/next"/>
 
         <ImageView
             android:id="@+id/repeat_btn"
@@ -88,7 +92,8 @@
             android:layout_weight="1"
             android:paddingTop="@dimen/small_margin"
             android:paddingBottom="@dimen/small_margin"
-            android:src="@drawable/ic_repeat"/>
+            android:src="@drawable/ic_repeat"
+            android:contentDescription="@string/enable_song_repetition"/>
 
     </LinearLayout>
 


### PR DESCRIPTION
Sets contentDescription attributes for the buttons in the item_navigation bar.
Also updates descriptions whenever the state of the shuffle or repeat button changes. (This is done when the color filter is applied).

This makes the app usable with screen readers.

fixes #192 