### PR TITLE
Create multiple playlists from folders at once

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/activities/MainActivity.kt
@@ -43,6 +43,7 @@ import kotlinx.android.synthetic.main.view_current_track_bar.*
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
+import java.io.File
 
 class MainActivity : SimpleActivity() {
     private var isSearchOpen = false
@@ -117,7 +118,7 @@ class MainActivity : SimpleActivity() {
             R.id.sort -> showSortingDialog()
             R.id.sleep_timer -> showSleepTimer()
             R.id.create_new_playlist -> createNewPlaylist()
-            R.id.create_playlist_from_folder -> createPlaylistFromFolder()
+            R.id.create_playlist_from_folder -> createPlaylistsFromFolder()
             R.id.equalizer -> launchEqualizer()
             R.id.settings -> launchSettings()
             R.id.about -> launchAbout()
@@ -245,17 +246,22 @@ class MainActivity : SimpleActivity() {
         }
     }
 
-    private fun createPlaylistFromFolder() {
+    private fun createPlaylistsFromFolder() {
         FilePickerDialog(this, pickFile = false) {
-            createPlaylistFrom(it)
+            val folders = File(it).listFiles { f -> f.isDirectory }
+            if (folders != null && folders.isNotEmpty())
+                folders.forEach { f -> createPlaylistFrom(f.absolutePath) }
+            else createPlaylistFrom(it)
         }
     }
 
     private fun createPlaylistFrom(path: String) {
         ensureBackgroundThread {
+            val name = path.reversed().split("/")[0].reversed()
             getFolderTracks(path, true) { tracks ->
                 runOnUiThread {
-                    NewPlaylistDialog(this) { playlistId ->
+                    NewPlaylistDialog(this, name)
+                    { playlistId ->
                         tracks.forEach {
                             it.playListId = playlistId
                         }

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/adapters/PlaylistsAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/adapters/PlaylistsAdapter.kt
@@ -142,7 +142,8 @@ class PlaylistsAdapter(activity: SimpleActivity, var playlists: ArrayList<Playli
     }
 
     private fun showRenameDialog() {
-        NewPlaylistDialog(activity, playlists[getItemKeyPosition(selectedKeys.first())]) {
+        val list = playlists[getItemKeyPosition(selectedKeys.first())]
+        NewPlaylistDialog(activity, list.title, list) {
             activity.runOnUiThread {
                 finishActMode()
             }

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/dialogs/NewPlaylistDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/dialogs/NewPlaylistDialog.kt
@@ -13,12 +13,12 @@ import com.simplemobiletools.musicplayer.extensions.playlistDAO
 import com.simplemobiletools.musicplayer.models.Playlist
 import kotlinx.android.synthetic.main.dialog_new_playlist.view.*
 
-class NewPlaylistDialog(val activity: Activity, var playlist: Playlist? = null, val callback: (playlistId: Int) -> Unit) {
+class NewPlaylistDialog(val activity: Activity, defaultName: String = "", var playlist: Playlist? = null, val callback: (playlistId: Int) -> Unit) {
     var isNewPlaylist = playlist == null
 
     init {
         if (playlist == null) {
-            playlist = Playlist(0, "")
+            playlist = Playlist(0, defaultName)
         }
 
         val view = activity.layoutInflater.inflate(R.layout.dialog_new_playlist, null).apply {

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -41,7 +41,7 @@
     <string name="empty_playlist">Huidige afspeellijst is leeg</string>
     <string name="fetching_songs">Nummers laden…</string>
     <string name="all_songs">Alle nummers</string>
-    <string name="create_playlist_from_folder">Van deze map nieuwe afspeellijst maken</string>
+    <string name="create_playlist_from_folder">Van deze map nieuwe afspeellijst(en) maken</string>
     <string name="folder_contains_no_audio">De geselecteerde map bevat geen geluidsbestanden</string>
     <string name="delete_current_song">Huidige nummer verwijderen</string>
     <string name="remove_current_song">Huidige nummer uit afspeellijst verwijderen</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,7 +41,7 @@
     <string name="empty_playlist">Current playlist is empty</string>
     <string name="fetching_songs">Fetching songs…</string>
     <string name="all_songs">All songs</string>
-    <string name="create_playlist_from_folder">Create new playlist from folder</string>
+    <string name="create_playlist_from_folder">Create new playlist(s) from folder</string>
     <string name="folder_contains_no_audio">The selected folder contains no audio files</string>
     <string name="delete_current_song">Delete current song</string>
     <string name="remove_current_song">Remove current song from playlist</string>


### PR DESCRIPTION
Add ability to add subfolders as playlists to "create playlist from folder". Either a playlist is created from a folder if it contains no subfolders, or else a playlist is created for each subfolder.

The latter would leave any files directly under the selected folder out of all created playlists.

I'm not sure if it's wise to add both the "create playlist from folder" and the "create playlist from subfolders" functionality under the same menu item, though it serves my own purposes. Feedback on this would be most welcome :)

Closes #195