### PR TITLE
Sliding track title and track artist feature

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/views/MarqueeTextView.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/views/MarqueeTextView.kt
@@ -1,0 +1,46 @@
+package com.simplemobiletools.musicplayer.views
+
+import android.content.Context
+import android.graphics.Rect
+import android.text.TextUtils
+import android.util.AttributeSet
+import android.view.View
+import androidx.appcompat.widget.AppCompatTextView
+
+
+class MarqueeTextView(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) :
+    AppCompatTextView(context!!, attrs, defStyleAttr), View.OnLayoutChangeListener {
+    constructor(context: Context?) : this(context, null) {}
+    constructor(context: Context?, attrs: AttributeSet?) : this(context, attrs, 0) {}
+
+    override fun isFocused(): Boolean {
+        return true
+    }
+
+    override fun onWindowFocusChanged(hasWindowFocus: Boolean) {
+        if (hasWindowFocus) super.onWindowFocusChanged(hasWindowFocus)
+    }
+
+    override fun onFocusChanged(focused: Boolean, direction: Int, previouslyFocusedRect: Rect?) {
+        if (focused) super.onFocusChanged(focused, direction, previouslyFocusedRect)
+    }
+
+    override fun onLayoutChange(
+        v: View?, left: Int, top: Int, right: Int, bottom: Int,
+        oldLeft: Int, oldTop: Int, oldRight: Int, oldBottom: Int
+    ) {
+        val layoutParams = layoutParams
+        layoutParams.height = bottom - top
+        layoutParams.width = right - left
+        removeOnLayoutChangeListener(this)
+        setLayoutParams(layoutParams)
+    }
+
+    init {
+        setSingleLine()
+        ellipsize = TextUtils.TruncateAt.MARQUEE
+        marqueeRepeatLimit = -1
+        isSelected = true
+        addOnLayoutChangeListener(this)
+    }
+}

--- a/app/src/main/res/layout/activity_track.xml
+++ b/app/src/main/res/layout/activity_track.xml
@@ -112,13 +112,12 @@
 
         <com.simplemobiletools.musicplayer.views.MarqueeTextView
             android:id="@+id/activity_track_title"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:width="800dp"
             android:fadingEdge="horizontal"
             android:scrollHorizontally="true"
             android:gravity="center"
-
             android:paddingStart="@dimen/activity_margin"
             android:paddingEnd="@dimen/activity_margin"
             android:textSize="@dimen/extra_big_text_size"
@@ -128,19 +127,21 @@
             app:layout_constraintTop_toBottomOf="@+id/activity_track_progress_current"
             tools:text="Track title"/>
 
-        <com.simplemobiletools.commons.views.MyTextView
+        <com.simplemobiletools.musicplayer.views.MarqueeTextView
             android:id="@+id/activity_track_artist"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:alpha="0.8"
-            android:ellipsize="end"
+            android:width="800dp"
+            android:fadingEdge="horizontal"
+            android:scrollHorizontally="true"
             android:gravity="center"
-            android:maxLines="1"
+            android:alpha="0.8"
             android:paddingStart="@dimen/activity_margin"
             android:paddingEnd="@dimen/activity_margin"
             android:textSize="@dimen/actionbar_text_size"
             app:layout_constraintBottom_toTopOf="@+id/activity_track_toggle_shuffle"
             app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/activity_track_title"
             tools:text="Track artist" />
 

--- a/app/src/main/res/layout/activity_track.xml
+++ b/app/src/main/res/layout/activity_track.xml
@@ -110,20 +110,23 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/activity_track_progressbar" />
 
-        <com.simplemobiletools.commons.views.MyTextView
+        <com.simplemobiletools.musicplayer.views.MarqueeTextView
             android:id="@+id/activity_track_title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:ellipsize="end"
+            android:width="800dp"
+            android:fadingEdge="horizontal"
+            android:scrollHorizontally="true"
             android:gravity="center"
-            android:maxLines="1"
+
             android:paddingStart="@dimen/activity_margin"
             android:paddingEnd="@dimen/activity_margin"
             android:textSize="@dimen/extra_big_text_size"
             app:layout_constraintBottom_toTopOf="@+id/activity_track_artist"
             app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/activity_track_progress_current"
-            tools:text="Track title" />
+            tools:text="Track title"/>
 
         <com.simplemobiletools.commons.views.MyTextView
             android:id="@+id/activity_track_artist"


### PR DESCRIPTION
According to the #302 open issue, marked as "feature request", I've implemented sliding track title and track artist.

In the current master version, the track title remains static : 
https://user-images.githubusercontent.com/66901396/119735870-4273b200-be7d-11eb-94cf-4a60762982ba.mp4

But according to my branch, this is how could appear the track title:
https://user-images.githubusercontent.com/66901396/119736090-823a9980-be7d-11eb-9607-2cda822fed5e.mp4

In the two videos, you can see this change only in the track title. But for the track artist is the same. 
Moreover, just consider that the track title/artist will slide only if it doesn't fit completely the screen.

