### PR TITLE
fix widget issues

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/MyWidgetProvider.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/MyWidgetProvider.kt
@@ -44,8 +44,17 @@ class MyWidgetProvider : AppWidgetProvider() {
         when (action) {
             TRACK_CHANGED -> songChanged(context, intent)
             TRACK_STATE_CHANGED -> songStateChanged(context, intent)
-            PREVIOUS, PLAYPAUSE, NEXT -> context.sendIntent(action)
+            PREVIOUS, PLAYPAUSE, NEXT -> handlePlayerControls(context, action)
             else -> super.onReceive(context, intent)
+        }
+    }
+
+    private fun handlePlayerControls(context: Context, action: String) {
+        if (MusicService.mCurrTrack == null) {
+            val intent = context.getLaunchIntent() ?: Intent(context, SplashActivity::class.java)
+            context.startActivity(intent)
+        } else {
+            context.sendIntent(action)
         }
     }
 
@@ -69,11 +78,12 @@ class MyWidgetProvider : AppWidgetProvider() {
     }
 
     private fun songChanged(context: Context, intent: Intent) {
-        val song = intent.getSerializableExtra(NEW_TRACK) as? Track ?: return
         val appWidgetManager = AppWidgetManager.getInstance(context) ?: return
+        val song = intent.getSerializableExtra(NEW_TRACK) as? Track
         appWidgetManager.getAppWidgetIds(getComponentName(context)).forEach {
             val views = getRemoteViews(appWidgetManager, context, it)
             updateSongInfo(views, song)
+            updatePlayPauseButton(context, views, MusicService.getIsPlaying())
             appWidgetManager.updateAppWidget(it, views)
         }
     }


### PR DESCRIPTION
**Notes**
- when there is no queue, open the app so users can play a song or create a queue
- when there is a queue, play the latest song in the queue
- clear widget title when the queue is cleared
- update widget play/pause state when a song is played
-  closes  #371 

Before:

https://user-images.githubusercontent.com/25648077/150023431-5f9062c5-e9e0-483a-90f4-18a5447ead20.mov


After:

https://user-images.githubusercontent.com/25648077/150023532-1fda7af1-1d09-4540-a2e6-383071f55ed2.mp4



