### PR TITLE
Add a landscape layout for item_playlist.xml

### DIFF
--- a/app/src/main/res/layout-land/item_playlist.xml
+++ b/app/src/main/res/layout-land/item_playlist.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/playlist_frame"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground"
+    android:clickable="true"
+    android:focusable="true"
+    android:foreground="@drawable/selector"
+    android:paddingStart="@dimen/medium_margin"
+    android:paddingTop="@dimen/activity_margin"
+    android:paddingEnd="@dimen/activity_margin"
+    android:paddingBottom="@dimen/activity_margin">
+
+    <com.simplemobiletools.commons.views.MyTextView
+        android:id="@+id/playlist_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerVertical="true"
+        android:paddingStart="@dimen/medium_margin"
+        android:paddingEnd="@dimen/medium_margin"
+        android:textSize="@dimen/big_text_size"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="packed"
+        tools:text="My Playlist" />
+
+    <com.simplemobiletools.commons.views.MyTextView
+        android:id="@+id/playlist_tracks"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:alpha="0.8"
+        android:paddingStart="@dimen/medium_margin"
+        android:paddingEnd="@dimen/medium_margin"
+        android:textSize="@dimen/normal_text_size"
+        app:layout_constraintBottom_toBottomOf="@+id/playlist_title"
+        app:layout_constraintStart_toEndOf="@+id/playlist_title"
+        tools:text="5 Tracks" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Hi, I add a landscape layout for item_playlist.xml, because many people like to use their phones in landscape mode. This landscape layout has the following characteristics:
1. Switch between portrait and landscape layout in real time while the app is running.
2. Align two texts in a row to avoid wasted space in landscape mode.

![MuMu20220725093906](https://user-images.githubusercontent.com/66421771/180677863-2a5bd492-c789-4d0d-9fb6-7795911403b1.png)

