### PR TITLE
Crash fixes and improvements

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/activities/TrackActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/activities/TrackActivity.kt
@@ -262,7 +262,9 @@ class TrackActivity : SimpleActivity(), PlaybackSpeedListener {
                                 activity_track_image.layoutParams.height = coverHeight
                             }
 
-                            activity_track_image.setImageDrawable(resource)
+                            runOnUiThread {
+                                activity_track_image.setImageDrawable(resource)
+                            }
                             return false
                         }
                     })

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/interfaces/QueueItemsDao.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/interfaces/QueueItemsDao.kt
@@ -20,8 +20,11 @@ interface QueueItemsDao {
     @Query("SELECT * FROM queue_items WHERE is_current = 1")
     fun getCurrent(): QueueItem?
 
+    @Query("UPDATE queue_items SET is_current = 1 WHERE track_id = :trackId")
+    fun saveCurrentTrack(trackId: Long)
+    
     @Query("UPDATE queue_items SET is_current = 1, last_position = :lastPosition WHERE track_id = :trackId")
-    fun saveCurrentTrack(trackId: Long, lastPosition: Int)
+    fun saveCurrentTrackProgress(trackId: Long, lastPosition: Int)
 
     @Query("UPDATE queue_items SET track_order = :order WHERE track_id = :trackId")
     fun setOrder(trackId: Long, order: Int)

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/services/MusicService.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/services/MusicService.kt
@@ -495,6 +495,7 @@ class MusicService : Service(), MediaPlayer.OnPreparedListener, MediaPlayer.OnEr
     }
 
     private fun stopForegroundAndNotification() {
+        notificationHandler.removeCallbacksAndMessages(null)
         @Suppress("DEPRECATION")
         stopForeground(true)
         notificationHelper?.cancel(NOTIFICATION_ID)

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/services/MusicService.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/services/MusicService.kt
@@ -325,7 +325,9 @@ class MusicService : Service(), MediaPlayer.OnPreparedListener, MediaPlayer.OnEr
     }
 
     fun handleDismiss() {
-        pauseTrack(false)
+        if (isPlaying()) {
+            pauseTrack(false)
+        }
         stopForegroundAndNotification()
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/services/MusicService.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/services/MusicService.kt
@@ -378,16 +378,19 @@ class MusicService : Service(), MediaPlayer.OnPreparedListener, MediaPlayer.OnEr
         updateUI()
     }
 
+    @Synchronized
     private fun updateUI() {
-        if (mPlayer != null) {
-            EventBus.getDefault().post(Events.QueueUpdated(mTracks))
-            mCurrTrackCover = getAlbumImage().first
-            trackChanged()
+        ensureBackgroundThread {
+            if (mPlayer != null) {
+                EventBus.getDefault().post(Events.QueueUpdated(mTracks))
+                mCurrTrackCover = getAlbumImage().first
+                trackChanged()
 
-            val secs = getPosition()!! / 1000
-            broadcastTrackProgress(secs)
+                val secs = getPosition()!! / 1000
+                broadcastTrackProgress(secs)
+            }
+            trackStateChanged(isPlaying())
         }
-        trackStateChanged(isPlaying())
     }
 
     private fun initMediaPlayerIfNeeded() {

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/services/MusicService.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/services/MusicService.kt
@@ -116,6 +116,9 @@ class MusicService : Service(), MediaPlayer.OnPreparedListener, MediaPlayer.OnEr
         mCoverArtHeight = resources.getDimension(R.dimen.top_art_height).toInt()
         createMediaSession()
 
+        notificationHelper = NotificationHelper.createInstance(context = this, mMediaSession!!)
+        startForegroundOrNotify()
+
         mAudioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
         if (isOreoPlus()) {
             mOreoFocusHandler = OreoAudioFocusHandler(application)
@@ -124,8 +127,6 @@ class MusicService : Service(), MediaPlayer.OnPreparedListener, MediaPlayer.OnEr
         if (!isQPlus() && !hasPermission(getPermissionToRequest())) {
             EventBus.getDefault().post(Events.NoStoragePermission())
         }
-
-        notificationHelper = NotificationHelper.createInstance(context = this, mMediaSession!!)
     }
 
     private fun createMediaSession() {

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/services/MusicService.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/services/MusicService.kt
@@ -1100,13 +1100,17 @@ class MusicService : Service(), MediaPlayer.OnPreparedListener, MediaPlayer.OnEr
     }
 
     private fun saveTrackProgress() {
-        if (mCurrTrack != null && getPosition() != 0) {
+        if (mCurrTrack != null) {
             ensureBackgroundThread {
                 val trackId = mCurrTrack?.mediaStoreId ?: return@ensureBackgroundThread
-                val position = getPosition() ?: return@ensureBackgroundThread
+                val position = getPosition()
                 queueDAO.apply {
                     resetCurrent()
-                    saveCurrentTrack(trackId, position)
+                    if (position == null || position == 0) {
+                        saveCurrentTrack(trackId)
+                    } else {
+                        saveCurrentTrackProgress(trackId, position)
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR attempts to reduce the number of `ForegroundServiceDidNotStartInTimeException` exceptions thrown by the system. I think they are mostly happening with third-party intents. Also added some other minor improvements.

### Changes/Notes: 
 - Call `startForeground()` as soon as possible
 - Always call`startForeground()` instead of only at startup: If some intent update is fired using `startForegroundService()` then sometimes the service crashes with `ForegroundServiceDidNotStartInTimeException` even if it's in the foreground. This was the case with one of the crash logs from the play store.
 -   Throttle frequent notification updates as in some cases the notification updates are ignored by the system leading to incomplete track info in the notification (reproducible on MIUI running android 12) 
 - Workaround ANR by using a background thread for fetching thumbnails. When playing very long files (audiobooks etc.) the MediaMetadataRetriever takes too long to return and that causes an ANR. This means delaying the notification updates until a thumbnail result is available. This could use some work.
 - Save current track info on track change, previously we only did this on pause/seek/dismiss.