### PR TITLE
change deprecated sumBy() to sumOf()

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/activities/AlbumsActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/activities/AlbumsActivity.kt
@@ -56,7 +56,7 @@ class AlbumsActivity : SimpleActivity() {
             albums.forEach {
                 val tracks = getAlbumTracksSync(it.id)
                 tracks.sortWith(compareBy({ it.trackId }, { it.title.lowercase() }))
-                trackFullDuration += tracks.sumBy { it.duration }
+                trackFullDuration += tracks.sumOf { it.duration }
                 tracksToAdd.addAll(tracks)
             }
 

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/activities/TracksActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/activities/TracksActivity.kt
@@ -224,7 +224,7 @@ class TracksActivity : SimpleActivity() {
                     tracks.addAll(albumTracks)
 
                     val coverArt = ContentUris.withAppendedId(artworkUri, album.id).toString()
-                    val header = AlbumHeader(album.title, coverArt, album.year, tracks.size, tracks.sumBy { it.duration }, album.artist)
+                    val header = AlbumHeader(album.title, coverArt, album.year, tracks.size, tracks.sumOf { it.duration }, album.artist)
                     listItems.add(header)
                     listItems.addAll(tracks)
                 }


### PR DESCRIPTION
**Changed Deprecated function sumBy() with sumOf()**

Android Studio Warning -> **sumBy((T) -> Int): Int' is deprecated. Use sumOf instead**

**For  -> AlbumsActivity**
It calculates the sum of the duration of the tracks of all the albums of a particular artist.

- [x] It is producing correct results.

**For  -> TracksActivity**
It calculates the sum of all the tracks present in a particular album.

- [x] It is producing correct result.

