### PR TITLE
Fix #48 volume slider added that changes the MediaPlayer volume

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/activities/TrackActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/activities/TrackActivity.kt
@@ -110,6 +110,7 @@ class TrackActivity : SimpleActivity(), PlaybackSpeedListener {
 
     override fun onResume() {
         super.onResume()
+        activity_volume_bar.progress = config.currentVolume
         updateTextColors(activity_track_holder)
         activity_track_title.setTextColor(getProperTextColor())
         activity_track_artist.setTextColor(getProperTextColor())
@@ -170,7 +171,7 @@ class TrackActivity : SimpleActivity(), PlaybackSpeedListener {
         setupShuffleButton()
         setupPlaybackSettingButton()
         setupSeekbar()
-
+        setupVolumeBar()
         arrayOf(activity_track_previous, activity_track_play_pause, activity_track_next).forEach {
             it.applyColorFilter(getProperTextColor())
         }
@@ -357,6 +358,25 @@ class TrackActivity : SimpleActivity(), PlaybackSpeedListener {
         })
     }
 
+    private fun setupVolumeBar(){
+        activity_volume_image_icon.applyColorFilter(getProperTextColor())
+        activity_volume_bar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener{
+            override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
+
+                Intent(this@TrackActivity, MusicService::class.java).apply {
+                    putExtra(VOLUME, seekBar.progress.toFloat())
+                    action = SET_VOLUME
+                    startService(this)
+                }
+            }
+
+            override fun onStartTrackingTouch(seekBar: SeekBar?) { }
+
+            override fun onStopTrackingTouch(seekBar: SeekBar) {
+                config.currentVolume = seekBar.progress
+            }
+        })
+    }
     private fun showPlaybackSpeedPicker() {
         val fragment = PlaybackSpeedFragment()
         fragment.show(supportFragmentManager, PlaybackSpeedFragment::class.java.simpleName)

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/Config.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/Config.kt
@@ -136,4 +136,8 @@ class Config(context: Context) : BaseConfig(context) {
     var gaplessPlayback: Boolean
         get() = prefs.getBoolean(GAPLESS_PLAYBACK, false)
         set(gaplessPlayback) = prefs.edit().putBoolean(GAPLESS_PLAYBACK, gaplessPlayback).apply()
+
+    var currentVolume: Int
+        get() = prefs.getInt(CURRENT_VOLUME, 25)
+        set(currentVolume) = prefs.edit().putInt(CURRENT_VOLUME, currentVolume).apply()
 }

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/Constants.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/Constants.kt
@@ -14,7 +14,7 @@ const val STOP_SLEEP_TIMER = "stop_sleep_timer"
 const val TRACK_ID = "track_id"
 const val RESTART_PLAYER = "RESTART_PLAYER"
 const val EQUALIZER_PRESET_CUSTOM = -1
-
+const val VOLUME = "volume"
 const val ARTIST = "artist"
 const val ALBUM = "album"
 const val TRACK = "track"
@@ -47,6 +47,7 @@ const val SET_PLAYBACK_SPEED = PATH + "SET_PLAYBACK_SPEED"
 const val UPDATE_QUEUE_SIZE = PATH + "UPDATE_QUEUE_SIZE"
 const val UPDATE_GAPLESS_PLAYBACK = PATH + "UPDATE_GAPLESS_PLAYBACK"
 const val TRACK_STATE_CHANGED = "TRACK_STATE_CHANGED"
+const val SET_VOLUME = PATH + "SET_VOLUME"
 
 // shared preferences
 const val SHUFFLE = "shuffle"
@@ -68,6 +69,7 @@ const val LAST_EXPORT_PATH = "last_export_path"
 const val EXCLUDED_FOLDERS = "excluded_folders"
 const val SORT_PLAYLIST_PREFIX = "sort_playlist_"
 const val GAPLESS_PLAYBACK = "gapless_playback"
+const val CURRENT_VOLUME = "current_volume"
 
 const val SHOW_FILENAME_NEVER = 1
 const val SHOW_FILENAME_IF_UNAVAILABLE = 2

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/MultiPlayer.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/MultiPlayer.kt
@@ -185,6 +185,10 @@ class MultiPlayer(private val app: Application, private val callbacks: PlaybackC
         }
     }
 
+    fun getCurrentVolume(): Float {
+        return audioManager!!.getStreamVolume(AudioManager.STREAM_MUSIC).toFloat()
+    }
+
     override fun onError(mp: MediaPlayer, what: Int, extra: Int): Boolean {
         isInitialized = false
         mCurrentMediaPlayer.reset()

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/services/MusicService.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/services/MusicService.kt
@@ -165,6 +165,7 @@ class MusicService : Service(), MultiPlayer.PlaybackCallbacks {
             SET_PLAYBACK_SPEED -> setPlaybackSpeed()
             UPDATE_QUEUE_SIZE -> updateQueueSize()
             UPDATE_GAPLESS_PLAYBACK -> updateGaplessPlayback()
+            SET_VOLUME -> changeVolumeTo(intent)
         }
 
         MediaButtonReceiver.handleIntent(mMediaSession!!, intent)
@@ -938,6 +939,11 @@ class MusicService : Service(), MultiPlayer.PlaybackCallbacks {
         mPlayer!!.seek(progress * 1000)
         saveTrackProgress()
         resumeTrack()
+    }
+
+    private fun changeVolumeTo(intent: Intent) {
+        val volume = intent.getFloatExtra(VOLUME, mPlayer!!.getCurrentVolume() / 100)
+        mPlayer!!.setVolume(volume / 100)
     }
 
     private fun trackStateChanged(isPlaying: Boolean = isPlaying(), notify: Boolean = true) {

--- a/app/src/main/res/drawable/ic_volume_vector.xml
+++ b/app/src/main/res/drawable/ic_volume_vector.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="#FFFFFF" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M3,9v6h4l5,5L12,4L7,9L3,9zM16.5,12c0,-1.77 -1.02,-3.29 -2.5,-4.03v8.05c1.48,-0.73 2.5,-2.25 2.5,-4.02zM14,3.23v2.06c2.89,0.86 5,3.54 5,6.71s-2.11,5.85 -5,6.71v2.06c4.01,-0.91 7,-4.49 7,-8.77s-2.99,-7.86 -7,-8.77z"/>
+</vector>

--- a/app/src/main/res/layout/activity_track.xml
+++ b/app/src/main/res/layout/activity_track.xml
@@ -110,6 +110,31 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/activity_track_progressbar" />
 
+        <LinearLayout
+            android:id="@+id/activity_volume_bar_layout"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/small_margin"
+            android:gravity="center"
+            android:orientation="horizontal"
+            app:layout_constraintBottom_toTopOf="@+id/activity_track_title"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/activity_track_progress_max">
+
+            <ImageView
+                android:id="@+id/activity_volume_image_icon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:src="@drawable/ic_volume_vector" />
+
+            <SeekBar
+                android:id="@+id/activity_volume_bar"
+                android:layout_width="128dp"
+                android:layout_height="wrap_content"
+                android:max="100" />
+        </LinearLayout>
+
         <com.simplemobiletools.musicplayer.views.MarqueeTextView
             android:id="@+id/activity_track_title"
             android:layout_width="wrap_content"
@@ -124,7 +149,7 @@
             app:layout_constraintBottom_toTopOf="@+id/activity_track_artist"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/activity_track_progress_current"
+            app:layout_constraintTop_toBottomOf="@+id/activity_volume_bar_layout"
             tools:text="Track title" />
 
         <com.simplemobiletools.musicplayer.views.MarqueeTextView


### PR DESCRIPTION
Fix #48

![Screenshot 2023-07-14 031519](https://github.com/SimpleMobileTools/Simple-Music-Player/assets/52420957/40de5616-3915-40ec-85d7-975b6945be87)

Added a _**Volume Slider**_ that changes the app's MediaPlayer's volume and not the phone's overall media volume.