### PR TITLE
Use a dot (•) instead of a hyphen (-) to separate track artists, albums

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/adapters/TracksAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/adapters/TracksAdapter.kt
@@ -211,9 +211,9 @@ class TracksAdapter(
             track_frame?.isSelected = selectedKeys.contains(track.hashCode())
             track_title.text = if (textToHighlight.isEmpty()) track.title else track.title.highlightTextPart(textToHighlight, properPrimaryColor)
             track_info.text = if (textToHighlight.isEmpty()) {
-                "${track.artist} - ${track.album}"
+                "${track.artist} • ${track.album}"
             } else {
-                ("${track.artist} - ${track.album}").highlightTextPart(textToHighlight, properPrimaryColor)
+                ("${track.artist} • ${track.album}").highlightTextPart(textToHighlight, properPrimaryColor)
             }
             track_drag_handle.beVisibleIf(isPlaylistContent && selectedKeys.isNotEmpty())
             track_drag_handle.applyColorFilter(textColor)


### PR DESCRIPTION
### Before: 
<img src="https://github.com/SimpleMobileTools/Simple-Music-Player/assets/36371707/18bbea12-fd6a-4511-b737-cee1dba68560" width=264 /> <img src="https://github.com/SimpleMobileTools/Simple-Music-Player/assets/36371707/de3eff55-57f3-499d-8222-ad64a0ce94b0" width=264 /> <img src="https://github.com/SimpleMobileTools/Simple-Music-Player/assets/36371707/55f36780-203d-4890-b05f-d4ec3de521e3" width=264 />

### After:
<img src="https://github.com/SimpleMobileTools/Simple-Music-Player/assets/36371707/228128cb-2352-41ff-8d00-563834bd32fc" width=264 /> <img src="https://github.com/SimpleMobileTools/Simple-Music-Player/assets/36371707/49c26193-ff1b-4dc3-b962-16afdfe5a76f" width=264 /> <img src="https://github.com/SimpleMobileTools/Simple-Music-Player/assets/36371707/b85e6901-dcee-4b51-8f4a-1c920cdc25b9" width=264 />


Maybe we should do this in other apps too, if there are things separated using a hyphen. A dot looks better IMO.