### PR TITLE
Improve file deletion

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/adapters/AlbumsTracksAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/adapters/AlbumsTracksAdapter.kt
@@ -179,6 +179,11 @@ class AlbumsTracksAdapter(
                         positions.forEach {
                             items.removeAt(it)
                         }
+
+                        // finish activity if all tracks are deleted
+                        if (items.none { it is Track }) {
+                            activity.finish()
+                        }
                     }
                 }
             }

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/adapters/TracksAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/adapters/TracksAdapter.kt
@@ -199,6 +199,11 @@ class TracksAdapter(
                         }
 
                         finishActMode()
+
+                        // finish activity if all tracks are deleted
+                        if (tracks.isEmpty()) {
+                            activity.finish()
+                        }
                     }
                 }
             }

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/adapters/TracksAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/adapters/TracksAdapter.kt
@@ -114,17 +114,9 @@ class TracksAdapter(
 
     override fun getItemKeyPosition(key: Int) = tracks.indexOfFirst { it.hashCode() == key }
 
-    override fun onActionModeCreated() {
-        if (isPlaylistContent) {
-            notifyDataSetChanged()
-        }
-    }
+    override fun onActionModeCreated() {}
 
-    override fun onActionModeDestroyed() {
-        if (isPlaylistContent) {
-            notifyDataSetChanged()
-        }
-    }
+    override fun onActionModeDestroyed() {}
 
     private fun addToPlaylist() {
         activity.addTracksToPlaylist(getSelectedTracks()) {

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/adapters/TracksAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/adapters/TracksAdapter.kt
@@ -201,7 +201,7 @@ class TracksAdapter(
                         finishActMode()
 
                         // finish activity if all tracks are deleted
-                        if (tracks.isEmpty()) {
+                        if (tracks.isEmpty() && !isPlaylistContent) {
                             activity.finish()
                         }
                     }

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/adapters/TracksHeaderAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/adapters/TracksHeaderAdapter.kt
@@ -160,6 +160,11 @@ class TracksHeaderAdapter(activity: SimpleActivity, var items: ArrayList<ListIte
                         positions.forEach {
                             items.removeAt(it)
                         }
+
+                        // finish activity if all tracks are deleted
+                        if (items.none { it is Track }) {
+                            activity.finish()
+                        }
                     }
                 }
             }

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/adapters/TracksHeaderAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/adapters/TracksHeaderAdapter.kt
@@ -227,7 +227,9 @@ class TracksHeaderAdapter(activity: SimpleActivity, var items: ArrayList<ListIte
                         }
                     }
                 } else {
-                    findViewById<ImageView>(R.id.album_image).setImageDrawable(placeholder)
+                    activity.runOnUiThread {
+                        findViewById<ImageView>(R.id.album_image).setImageDrawable(placeholder)
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/extensions/Activity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/extensions/Activity.kt
@@ -109,12 +109,12 @@ fun BaseSimpleActivity.deleteTracks(tracks: List<Track>, callback: () -> Unit) {
 }
 
 private fun Activity.maybeRescanTrackPaths(tracks: List<Track>, callback: (tracks: List<Track>) -> Unit) {
-    val tracksWithoutId = tracks.filter { it.mediaStoreId == 0L || it.flags and FLAG_MANUAL_CACHE != 0 }
+    val tracksWithoutId = tracks.filter { it.mediaStoreId == 0L || (it.flags and FLAG_MANUAL_CACHE) != 0 }
     if (tracksWithoutId.isNotEmpty()) {
         val pathsToRescan = tracksWithoutId.map { it.path }
         rescanPaths(pathsToRescan) {
             for (track in tracks) {
-                if (track.mediaStoreId == 0L || track.flags and FLAG_MANUAL_CACHE != 0) {
+                if (track.mediaStoreId == 0L || (track.flags and FLAG_MANUAL_CACHE) != 0) {
                     track.mediaStoreId = getMediaStoreIdFromPath(track.path)
                 }
             }

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/extensions/Activity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/extensions/Activity.kt
@@ -69,10 +69,15 @@ fun Activity.playNextInQueue(track: Track, callback: () -> Unit) {
 }
 
 fun BaseSimpleActivity.deleteTracks(tracks: List<Track>, callback: () -> Unit) {
+    try {
+        audioHelper.deleteTracks(tracks)
+        audioHelper.removeInvalidAlbumsArtists()
+    } catch (ignored: Exception) {
+    }
+
     val contentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI
     maybeRescanTrackPaths(tracks) { tracksToDelete ->
         if (tracksToDelete.isNotEmpty()) {
-            audioHelper.deleteTracks(tracksToDelete)
             if (isRPlus()) {
                 val uris = tracksToDelete.map { ContentUris.withAppendedId(contentUri, it.mediaStoreId) }
                 deleteSDK30Uris(uris) { success ->

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/extensions/Activity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/extensions/Activity.kt
@@ -109,12 +109,12 @@ fun BaseSimpleActivity.deleteTracks(tracks: List<Track>, callback: () -> Unit) {
 }
 
 private fun Activity.maybeRescanTrackPaths(tracks: List<Track>, callback: (tracks: List<Track>) -> Unit) {
-    val tracksWithoutId = tracks.filter { (it.mediaStoreId == 0L) || ((it.flags and FLAG_MANUAL_CACHE) != 0) }
+    val tracksWithoutId = tracks.filter { it.mediaStoreId == 0L || (it.flags and FLAG_MANUAL_CACHE != 0) }
     if (tracksWithoutId.isNotEmpty()) {
         val pathsToRescan = tracksWithoutId.map { it.path }
         rescanPaths(pathsToRescan) {
             for (track in tracks) {
-                if ((track.mediaStoreId == 0L) || ((track.flags and FLAG_MANUAL_CACHE) != 0)) {
+                if (track.mediaStoreId == 0L || (track.flags and FLAG_MANUAL_CACHE != 0)) {
                     track.mediaStoreId = getMediaStoreIdFromPath(track.path)
                 }
             }

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/extensions/Activity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/extensions/Activity.kt
@@ -109,12 +109,12 @@ fun BaseSimpleActivity.deleteTracks(tracks: List<Track>, callback: () -> Unit) {
 }
 
 private fun Activity.maybeRescanTrackPaths(tracks: List<Track>, callback: (tracks: List<Track>) -> Unit) {
-    val tracksWithoutId = tracks.filter { it.mediaStoreId == 0L || (it.flags and FLAG_MANUAL_CACHE) != 0 }
+    val tracksWithoutId = tracks.filter { (it.mediaStoreId == 0L) || ((it.flags and FLAG_MANUAL_CACHE) != 0) }
     if (tracksWithoutId.isNotEmpty()) {
         val pathsToRescan = tracksWithoutId.map { it.path }
         rescanPaths(pathsToRescan) {
             for (track in tracks) {
-                if (track.mediaStoreId == 0L || (track.flags and FLAG_MANUAL_CACHE) != 0) {
+                if ((track.mediaStoreId == 0L) || ((track.flags and FLAG_MANUAL_CACHE) != 0)) {
                     track.mediaStoreId = getMediaStoreIdFromPath(track.path)
                 }
             }

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/fragments/FoldersFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/fragments/FoldersFragment.kt
@@ -30,12 +30,7 @@ class FoldersFragment(context: Context, attributeSet: AttributeSet) : MyViewPage
 
     override fun setupFragment(activity: BaseSimpleActivity) {
         ensureBackgroundThread {
-            var tracks = context.audioHelper.getAllTracks()
-            tracks = tracks.distinctBy { "${it.path}/${it.mediaStoreId}" }.toMutableList() as ArrayList<Track>
-
-            Track.sorting = context.config.trackSorting
-            tracks.sort()
-
+            val tracks = context.audioHelper.getAllTracks()
             val foldersMap = tracks.groupBy { it.folderName }
             val folders = ArrayList<Folder>()
             val excludedFolders = activity.config.excludedFolders

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/AudioHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/AudioHelper.kt
@@ -57,8 +57,14 @@ class AudioHelper(private val context: Context) {
         context.tracksDAO.removeTrack(mediaStoreId)
     }
 
-    fun deleteTracks(albums: List<Track>) {
-        context.tracksDAO.removeTracks(albums.toList())
+    fun deleteTracks(tracks: List<Track>) {
+        tracks.forEach {
+            deleteTrack(it.mediaStoreId)
+        }
+    }
+
+    fun insertArtists(artists: List<Artist>) {
+        context.artistDAO.insertAll(artists)
     }
 
     fun getAllArtists(): ArrayList<Artist> {
@@ -85,8 +91,18 @@ class AudioHelper(private val context: Context) {
         )
     }
 
+    fun deleteArtist(id: Long) {
+        context.artistDAO.deleteArtist(id)
+    }
+
     fun deleteArtists(artists: List<Artist>) {
-        context.artistDAO.deleteAll(artists)
+        artists.forEach {
+            deleteArtist(it.id)
+        }
+    }
+
+    fun insertAlbums(albums: List<Album>) {
+        context.albumsDAO.insertAll(albums)
     }
 
     fun getAlbum(albumId: Long): Album? {
@@ -111,8 +127,14 @@ class AudioHelper(private val context: Context) {
             .distinctBy { "${it.path}/${it.mediaStoreId}" } as ArrayList<Track>
     }
 
+    private fun deleteAlbum(id: Long) {
+        context.albumsDAO.deleteAlbum(id)
+    }
+
     fun deleteAlbums(albums: List<Album>) {
-        context.albumsDAO.deleteAll(albums.toList())
+        albums.forEach {
+            deleteAlbum(it.id)
+        }
     }
 
     fun insertPlaylist(playlist: Playlist): Long {

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/AudioHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/AudioHelper.kt
@@ -173,4 +173,16 @@ class AudioHelper(private val context: Context) {
             context.tracksDAO.removePlaylistSongs(it.id)
         }
     }
+
+    fun removeInvalidAlbumsArtists() {
+        val tracks = context.tracksDAO.getAll()
+        val albums = context.albumsDAO.getAll()
+        val artists = context.artistDAO.getAll()
+
+        val invalidAlbums = albums.filter { album -> tracks.none { it.albumId == album.id } }
+        deleteAlbums(invalidAlbums)
+
+        val invalidArtists = artists.filter { artist -> tracks.none { it.artistId == artist.id } }
+        deleteArtists(invalidArtists)
+    }
 }

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/AudioHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/AudioHelper.kt
@@ -25,8 +25,12 @@ class AudioHelper(private val context: Context) {
     }
 
     fun getAllTracks(): ArrayList<Track> {
-        return context.tracksDAO.getAll()
+        val tracks = context.tracksDAO.getAll()
             .distinctBy { "${it.path}/${it.mediaStoreId}" } as ArrayList<Track>
+
+        Track.sorting = config.trackSorting
+        tracks.sort()
+        return tracks
     }
 
     fun getFolderTracks(folder: String): ArrayList<Track> {

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/interfaces/AlbumsDao.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/interfaces/AlbumsDao.kt
@@ -22,7 +22,4 @@ interface AlbumsDao {
 
     @Query("DELETE FROM albums WHERE id = :id")
     fun deleteAlbum(id: Long)
-
-    @Delete
-    fun deleteAll(albums: List<Album>)
 }

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/interfaces/ArtistsDao.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/interfaces/ArtistsDao.kt
@@ -16,7 +16,4 @@ interface ArtistsDao {
 
     @Query("DELETE FROM artists WHERE id = :id")
     fun deleteArtist(id: Long)
-
-    @Delete
-    fun deleteAll(artists: List<Artist>)
 }

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/interfaces/SongsDao.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/interfaces/SongsDao.kt
@@ -32,9 +32,6 @@ interface SongsDao {
     @Query("SELECT * FROM tracks WHERE media_store_id = :mediaStoreId")
     fun getTrackWithMediaStoreId(mediaStoreId: Long): Track?
 
-    @Delete
-    fun removeTracks(songs: List<Track>)
-
     @Query("DELETE FROM tracks WHERE media_store_id = :mediaStoreId")
     fun removeTrack(mediaStoreId: Long)
 


### PR DESCRIPTION
### Changes:
 - Rescan paths when updating the local cache and when deleting files (so that we can create delete requests on R+).
 - Avoid using `@Delete` and delete items one by one as it doesn't reflect the db changes immediately (thus UI isn't updated on time).
 - Avoid calling `notifyDatasetChanged()` when displaying playlist tracks. Drag handles will still appear in action mode. I double-checked.
 - Finish activity when all tracks are deleted as it doesn't make sense to show an artist/album without albums/tracks.
 - Fix UI update glitch when deleting folder tracks.