### PR TITLE
Allow sorting by date added

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/databases/SongsDatabase.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/databases/SongsDatabase.kt
@@ -10,7 +10,7 @@ import com.simplemobiletools.musicplayer.interfaces.*
 import com.simplemobiletools.musicplayer.models.*
 import com.simplemobiletools.musicplayer.objects.MyExecutor
 
-@Database(entities = [Track::class, Playlist::class, QueueItem::class, Artist::class, Album::class], version = 12)
+@Database(entities = [Track::class, Playlist::class, QueueItem::class, Artist::class, Album::class], version = 13)
 abstract class SongsDatabase : RoomDatabase() {
 
     abstract fun SongsDao(): SongsDao
@@ -43,6 +43,7 @@ abstract class SongsDatabase : RoomDatabase() {
                             .addMigrations(MIGRATION_9_10)
                             .addMigrations(MIGRATION_10_11)
                             .addMigrations(MIGRATION_11_12)
+                            .addMigrations(MIGRATION_12_13)
                             .build()
                     }
                 }
@@ -181,6 +182,13 @@ abstract class SongsDatabase : RoomDatabase() {
                     execSQL("ALTER TABLE artists_new RENAME TO artists")
                     execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_artists_id` ON `artists` (`id`)")
                 }
+            }
+        }
+
+        private val MIGRATION_12_13 = object: Migration(12, 13) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE tracks ADD COLUMN date_added INTEGER NOT NULL DEFAULT 0")
+                database.execSQL("ALTER TABLE albums ADD COLUMN date_added INTEGER NOT NULL DEFAULT 0")
             }
         }
     }

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/databases/SongsDatabase.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/databases/SongsDatabase.kt
@@ -10,7 +10,7 @@ import com.simplemobiletools.musicplayer.interfaces.*
 import com.simplemobiletools.musicplayer.models.*
 import com.simplemobiletools.musicplayer.objects.MyExecutor
 
-@Database(entities = [Track::class, Playlist::class, QueueItem::class, Artist::class, Album::class], version = 13)
+@Database(entities = [Track::class, Playlist::class, QueueItem::class, Artist::class, Album::class], version = 12)
 abstract class SongsDatabase : RoomDatabase() {
 
     abstract fun SongsDao(): SongsDao
@@ -43,7 +43,6 @@ abstract class SongsDatabase : RoomDatabase() {
                             .addMigrations(MIGRATION_9_10)
                             .addMigrations(MIGRATION_10_11)
                             .addMigrations(MIGRATION_11_12)
-                            .addMigrations(MIGRATION_12_13)
                             .build()
                     }
                 }
@@ -181,14 +180,10 @@ abstract class SongsDatabase : RoomDatabase() {
                     execSQL("DROP TABLE artists")
                     execSQL("ALTER TABLE artists_new RENAME TO artists")
                     execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_artists_id` ON `artists` (`id`)")
-                }
-            }
-        }
 
-        private val MIGRATION_12_13 = object: Migration(12, 13) {
-            override fun migrate(database: SupportSQLiteDatabase) {
-                database.execSQL("ALTER TABLE tracks ADD COLUMN date_added INTEGER NOT NULL DEFAULT 0")
-                database.execSQL("ALTER TABLE albums ADD COLUMN date_added INTEGER NOT NULL DEFAULT 0")
+                    database.execSQL("ALTER TABLE tracks ADD COLUMN date_added INTEGER NOT NULL DEFAULT 0")
+                    database.execSQL("ALTER TABLE albums ADD COLUMN date_added INTEGER NOT NULL DEFAULT 0")
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/dialogs/ChangeSortingDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/dialogs/ChangeSortingDialog.kt
@@ -76,18 +76,21 @@ class ChangeSortingDialog(val activity: Activity, val location: Int, val playlis
                 radioItems.add(RadioItem(0, activity.getString(R.string.title), PLAYER_SORT_BY_TITLE))
                 radioItems.add(RadioItem(1, activity.getString(R.string.artist_name), PLAYER_SORT_BY_ARTIST_TITLE))
                 radioItems.add(RadioItem(2, activity.getString(R.string.year), PLAYER_SORT_BY_YEAR))
+                radioItems.add(RadioItem(4, activity.getString(R.string.date_added), PLAYER_SORT_BY_DATE_ADDED))
             }
             TAB_TRACKS -> {
                 radioItems.add(RadioItem(0, activity.getString(R.string.title), PLAYER_SORT_BY_TITLE))
                 radioItems.add(RadioItem(1, activity.getString(R.string.artist), PLAYER_SORT_BY_ARTIST_TITLE))
                 radioItems.add(RadioItem(2, activity.getString(R.string.duration), PLAYER_SORT_BY_DURATION))
                 radioItems.add(RadioItem(3, activity.getString(R.string.track_number), PLAYER_SORT_BY_TRACK_ID))
+                radioItems.add(RadioItem(4, activity.getString(R.string.date_added), PLAYER_SORT_BY_DATE_ADDED))
             }
             ACTIVITY_PLAYLIST_FOLDER -> {
                 radioItems.add(RadioItem(0, activity.getString(R.string.title), PLAYER_SORT_BY_TITLE))
                 radioItems.add(RadioItem(1, activity.getString(R.string.artist), PLAYER_SORT_BY_ARTIST_TITLE))
                 radioItems.add(RadioItem(2, activity.getString(R.string.duration), PLAYER_SORT_BY_DURATION))
                 radioItems.add(RadioItem(3, activity.getString(R.string.track_number), PLAYER_SORT_BY_TRACK_ID))
+                radioItems.add(RadioItem(4, activity.getString(R.string.date_added), PLAYER_SORT_BY_DATE_ADDED))
 
                 if (playlist != null) {
                     radioItems.add(RadioItem(4, activity.getString(R.string.custom), PLAYER_SORT_BY_CUSTOM))

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/fragments/AlbumsFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/fragments/AlbumsFragment.kt
@@ -28,7 +28,7 @@ import kotlinx.android.synthetic.main.fragment_albums.view.albums_placeholder
 
 // Artists -> Albums -> Tracks
 class AlbumsFragment(context: Context, attributeSet: AttributeSet) : MyViewPagerFragment(context, attributeSet) {
-    private var albumsIgnoringSearch = ArrayList<Album>()
+    private var albums = ArrayList<Album>()
 
     override fun setupFragment(activity: BaseSimpleActivity) {
         Album.sorting = context.config.albumSorting
@@ -40,8 +40,8 @@ class AlbumsFragment(context: Context, attributeSet: AttributeSet) : MyViewPager
         }
     }
 
-    private fun gotAlbums(activity: BaseSimpleActivity, albums: ArrayList<Album>) {
-        albumsIgnoringSearch = albums
+    private fun gotAlbums(activity: BaseSimpleActivity, cachedAlbums: ArrayList<Album>) {
+        albums = cachedAlbums
 
         activity.runOnUiThread {
             val scanning = activity.mediaScanner.isScanning()
@@ -81,20 +81,19 @@ class AlbumsFragment(context: Context, attributeSet: AttributeSet) : MyViewPager
     }
 
     override fun onSearchQueryChanged(text: String) {
-        val filtered = albumsIgnoringSearch.filter { it.title.contains(text, true) }.toMutableList() as ArrayList<Album>
+        val filtered = albums.filter { it.title.contains(text, true) }.toMutableList() as ArrayList<Album>
         (albums_list.adapter as? AlbumsAdapter)?.updateItems(filtered, text)
         albums_placeholder.beVisibleIf(filtered.isEmpty())
     }
 
     override fun onSearchClosed() {
-        (albums_list.adapter as? AlbumsAdapter)?.updateItems(albumsIgnoringSearch)
-        albums_placeholder.beGoneIf(albumsIgnoringSearch.isNotEmpty())
+        (albums_list.adapter as? AlbumsAdapter)?.updateItems(albums)
+        albums_placeholder.beGoneIf(albums.isNotEmpty())
     }
 
     override fun onSortOpen(activity: SimpleActivity) {
         ChangeSortingDialog(activity, TAB_ALBUMS) {
             val adapter = albums_list.adapter as? AlbumsAdapter ?: return@ChangeSortingDialog
-            val albums = adapter.albums
             Album.sorting = activity.config.albumSorting
             albums.sort()
             adapter.updateItems(albums, forceUpdate = true)

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/fragments/ArtistsFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/fragments/ArtistsFragment.kt
@@ -28,7 +28,7 @@ import kotlinx.android.synthetic.main.fragment_artists.view.artists_placeholder
 
 // Artists -> Albums -> Tracks
 class ArtistsFragment(context: Context, attributeSet: AttributeSet) : MyViewPagerFragment(context, attributeSet) {
-    private var artistsIgnoringSearch = ArrayList<Artist>()
+    private var artists = ArrayList<Artist>()
 
     override fun setupFragment(activity: BaseSimpleActivity) {
         Artist.sorting = context.config.artistSorting
@@ -40,8 +40,8 @@ class ArtistsFragment(context: Context, attributeSet: AttributeSet) : MyViewPage
         }
     }
 
-    private fun gotArtists(activity: BaseSimpleActivity, artists: ArrayList<Artist>) {
-        artistsIgnoringSearch = artists
+    private fun gotArtists(activity: BaseSimpleActivity, cachedArtists: ArrayList<Artist>) {
+        artists = cachedArtists
         activity.runOnUiThread {
             val scanning = activity.mediaScanner.isScanning()
             artists_placeholder.text = if (scanning) {
@@ -80,20 +80,19 @@ class ArtistsFragment(context: Context, attributeSet: AttributeSet) : MyViewPage
     }
 
     override fun onSearchQueryChanged(text: String) {
-        val filtered = artistsIgnoringSearch.filter { it.title.contains(text, true) }.toMutableList() as ArrayList<Artist>
+        val filtered = artists.filter { it.title.contains(text, true) }.toMutableList() as ArrayList<Artist>
         (artists_list.adapter as? ArtistsAdapter)?.updateItems(filtered, text)
         artists_placeholder.beVisibleIf(filtered.isEmpty())
     }
 
     override fun onSearchClosed() {
-        (artists_list.adapter as? ArtistsAdapter)?.updateItems(artistsIgnoringSearch)
-        artists_placeholder.beGoneIf(artistsIgnoringSearch.isNotEmpty())
+        (artists_list.adapter as? ArtistsAdapter)?.updateItems(artists)
+        artists_placeholder.beGoneIf(artists.isNotEmpty())
     }
 
     override fun onSortOpen(activity: SimpleActivity) {
         ChangeSortingDialog(activity, TAB_ARTISTS) {
             val adapter = artists_list.adapter as? ArtistsAdapter ?: return@ChangeSortingDialog
-            val artists = adapter.artists
             Artist.sorting = activity.config.artistSorting
             artists.sort()
             adapter.updateItems(artists, forceUpdate = true)

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/fragments/FoldersFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/fragments/FoldersFragment.kt
@@ -19,14 +19,13 @@ import com.simplemobiletools.musicplayer.extensions.mediaScanner
 import com.simplemobiletools.musicplayer.helpers.FOLDER
 import com.simplemobiletools.musicplayer.helpers.TAB_FOLDERS
 import com.simplemobiletools.musicplayer.models.Folder
-import com.simplemobiletools.musicplayer.models.Track
 import kotlinx.android.synthetic.main.fragment_folders.view.folders_fastscroller
 import kotlinx.android.synthetic.main.fragment_folders.view.folders_list
 import kotlinx.android.synthetic.main.fragment_folders.view.folders_placeholder
 import kotlinx.android.synthetic.main.fragment_folders.view.folders_placeholder_2
 
 class FoldersFragment(context: Context, attributeSet: AttributeSet) : MyViewPagerFragment(context, attributeSet) {
-    private var foldersIgnoringSearch = ArrayList<Folder>()
+    private var folders = ArrayList<Folder>()
 
     override fun setupFragment(activity: BaseSimpleActivity) {
         ensureBackgroundThread {
@@ -70,7 +69,7 @@ class FoldersFragment(context: Context, attributeSet: AttributeSet) : MyViewPage
 
                 Folder.sorting = activity.config.folderSorting
                 folders.sort()
-                foldersIgnoringSearch = folders
+                this.folders = folders
 
                 val adapter = folders_list.adapter
                 if (adapter == null) {
@@ -99,20 +98,19 @@ class FoldersFragment(context: Context, attributeSet: AttributeSet) : MyViewPage
     }
 
     override fun onSearchQueryChanged(text: String) {
-        val filtered = foldersIgnoringSearch.filter { it.title.contains(text, true) }.toMutableList() as ArrayList<Folder>
+        val filtered = folders.filter { it.title.contains(text, true) }.toMutableList() as ArrayList<Folder>
         (folders_list.adapter as? FoldersAdapter)?.updateItems(filtered, text)
         folders_placeholder.beVisibleIf(filtered.isEmpty())
     }
 
     override fun onSearchClosed() {
-        (folders_list.adapter as? FoldersAdapter)?.updateItems(foldersIgnoringSearch)
-        folders_placeholder.beGoneIf(foldersIgnoringSearch.isNotEmpty())
+        (folders_list.adapter as? FoldersAdapter)?.updateItems(folders)
+        folders_placeholder.beGoneIf(folders.isNotEmpty())
     }
 
     override fun onSortOpen(activity: SimpleActivity) {
         ChangeSortingDialog(activity, TAB_FOLDERS) {
             val adapter = folders_list.adapter as? FoldersAdapter ?: return@ChangeSortingDialog
-            val folders = adapter.folders
             Folder.sorting = activity.config.folderSorting
             folders.sort()
             adapter.updateItems(folders, forceUpdate = true)

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/fragments/PlaylistsFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/fragments/PlaylistsFragment.kt
@@ -28,7 +28,7 @@ import kotlinx.android.synthetic.main.fragment_playlists.view.playlists_placehol
 import org.greenrobot.eventbus.EventBus
 
 class PlaylistsFragment(context: Context, attributeSet: AttributeSet) : MyViewPagerFragment(context, attributeSet) {
-    private var playlistsIgnoringSearch = ArrayList<Playlist>()
+    private var playlists = ArrayList<Playlist>()
 
     override fun setupFragment(activity: BaseSimpleActivity) {
         playlists_placeholder_2.underlineText()
@@ -46,7 +46,7 @@ class PlaylistsFragment(context: Context, attributeSet: AttributeSet) : MyViewPa
 
             Playlist.sorting = context.config.playlistSorting
             playlists.sort()
-            playlistsIgnoringSearch = playlists
+            this.playlists = playlists
 
             activity.runOnUiThread {
                 val scanning = activity.mediaScanner.isScanning()
@@ -85,22 +85,21 @@ class PlaylistsFragment(context: Context, attributeSet: AttributeSet) : MyViewPa
     }
 
     override fun onSearchQueryChanged(text: String) {
-        val filtered = playlistsIgnoringSearch.filter { it.title.contains(text, true) }.toMutableList() as ArrayList<Playlist>
+        val filtered = playlists.filter { it.title.contains(text, true) }.toMutableList() as ArrayList<Playlist>
         (playlists_list.adapter as? PlaylistsAdapter)?.updateItems(filtered, text)
         playlists_placeholder.beVisibleIf(filtered.isEmpty())
         playlists_placeholder_2.beVisibleIf(filtered.isEmpty())
     }
 
     override fun onSearchClosed() {
-        (playlists_list.adapter as? PlaylistsAdapter)?.updateItems(playlistsIgnoringSearch)
-        playlists_placeholder.beGoneIf(playlistsIgnoringSearch.isNotEmpty())
-        playlists_placeholder_2.beGoneIf(playlistsIgnoringSearch.isNotEmpty())
+        (playlists_list.adapter as? PlaylistsAdapter)?.updateItems(playlists)
+        playlists_placeholder.beGoneIf(playlists.isNotEmpty())
+        playlists_placeholder_2.beGoneIf(playlists.isNotEmpty())
     }
 
     override fun onSortOpen(activity: SimpleActivity) {
         ChangeSortingDialog(activity, TAB_PLAYLISTS) {
             val adapter = playlists_list.adapter as? PlaylistsAdapter ?: return@ChangeSortingDialog
-            val playlists = adapter.playlists
             Playlist.sorting = activity.config.playlistSorting
             playlists.sort()
             adapter.updateItems(playlists, forceUpdate = true)

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/fragments/TracksFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/fragments/TracksFragment.kt
@@ -33,15 +33,13 @@ class TracksFragment(context: Context, attributeSet: AttributeSet) : MyViewPager
 
     override fun setupFragment(activity: BaseSimpleActivity) {
         ensureBackgroundThread {
+            Track.sorting = context.config.trackSorting
             tracks = context.audioHelper.getAllTracks()
 
             val excludedFolders = context.config.excludedFolders
             tracks = tracks.filter {
                 !excludedFolders.contains(it.path.getParentPath())
             }.toMutableList() as ArrayList<Track>
-
-            Track.sorting = context.config.trackSorting
-            tracks.sort()
 
             activity.runOnUiThread {
                 val scanning = activity.mediaScanner.isScanning()

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/fragments/TracksFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/fragments/TracksFragment.kt
@@ -102,7 +102,6 @@ class TracksFragment(context: Context, attributeSet: AttributeSet) : MyViewPager
     override fun onSortOpen(activity: SimpleActivity) {
         ChangeSortingDialog(activity, TAB_TRACKS) {
             val adapter = tracks_list.adapter as? TracksAdapter ?: return@ChangeSortingDialog
-            val tracks = adapter.tracks
             Track.sorting = activity.config.trackSorting
             tracks.sort()
             adapter.updateItems(tracks, forceUpdate = true)

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/AudioHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/AudioHelper.kt
@@ -28,7 +28,6 @@ class AudioHelper(private val context: Context) {
         val tracks = context.tracksDAO.getAll()
             .distinctBy { "${it.path}/${it.mediaStoreId}" } as ArrayList<Track>
 
-        Track.sorting = config.trackSorting
         tracks.sort()
         return tracks
     }

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/Constants.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/Constants.kt
@@ -117,6 +117,7 @@ const val PLAYER_SORT_BY_DURATION = 16
 const val PLAYER_SORT_BY_ARTIST_TITLE = 32
 const val PLAYER_SORT_BY_TRACK_ID = 64
 const val PLAYER_SORT_BY_CUSTOM = 128
+const val PLAYER_SORT_BY_DATE_ADDED = 256
 
 const val PLAYLIST_SORTING = "playlist_sorting"
 const val PLAYLIST_TRACKS_SORTING = "playlist_tracks_sorting"

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/RoomHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/RoomHelper.kt
@@ -11,6 +11,7 @@ import com.simplemobiletools.musicplayer.extensions.config
 import com.simplemobiletools.musicplayer.models.Events
 import com.simplemobiletools.musicplayer.models.Track
 import org.greenrobot.eventbus.EventBus
+import java.io.File
 
 class RoomHelper(val context: Context) {
     fun insertTracksWithPlaylist(tracks: ArrayList<Track>) {
@@ -66,13 +67,14 @@ class RoomHelper(val context: Context) {
                 val albumId = cursor.getLongValue(Audio.Media.ALBUM_ID)
                 val coverArt = ContentUris.withAppendedId(artworkUri, albumId).toString()
                 val year = cursor.getIntValue(Audio.Media.YEAR)
+                val dateAdded = cursor.getIntValue(Audio.Media.DATE_ADDED)
                 val folderName = if (isQPlus()) {
                     cursor.getStringValue(Audio.Media.BUCKET_DISPLAY_NAME) ?: MediaStore.UNKNOWN_STRING
                 } else {
                     ""
                 }
 
-                val song = Track(0, mediaStoreId, title, artist, path, duration, album, coverArt, playlistId, 0, folderName, albumId, artistId, year, 0)
+                val song = Track(0, mediaStoreId, title, artist, path, duration, album, coverArt, playlistId, 0, folderName, albumId, artistId, year, dateAdded, 0)
                 song.title = song.getProperTitle(showFilename)
                 songs.add(song)
                 pathsMap.remove(path)
@@ -83,7 +85,13 @@ class RoomHelper(val context: Context) {
             val unknown = MediaStore.UNKNOWN_STRING
             val title = context.getTitle(it) ?: unknown
             val artist = context.getArtist(it) ?: unknown
-            val song = Track(0, 0, title, artist, it, context.getDuration(it) ?: 0, "", "", playlistId, 0, "", 0, 0, 0, 0)
+            val dateAdded = try {
+                (File(it).lastModified() / 1000L).toInt()
+            } catch (e: Exception) {
+                0
+            }
+
+            val song = Track(0, 0, title, artist, it, context.getDuration(it) ?: 0, "", "", playlistId, 0, "", 0, 0, 0,dateAdded ,0)
             song.title = song.getProperTitle(showFilename)
             songs.add(song)
         }

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/models/Album.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/models/Album.kt
@@ -8,6 +8,7 @@ import androidx.room.PrimaryKey
 import com.simplemobiletools.commons.helpers.AlphanumericComparator
 import com.simplemobiletools.commons.helpers.SORT_DESCENDING
 import com.simplemobiletools.musicplayer.helpers.PLAYER_SORT_BY_ARTIST_TITLE
+import com.simplemobiletools.musicplayer.helpers.PLAYER_SORT_BY_DATE_ADDED
 import com.simplemobiletools.musicplayer.helpers.PLAYER_SORT_BY_TITLE
 
 @Entity(tableName = "albums", indices = [(Index(value = ["id"], unique = true))])
@@ -18,7 +19,8 @@ data class Album(
     @ColumnInfo(name = "cover_art") val coverArt: String,
     @ColumnInfo(name = "year") val year: Int,
     @ColumnInfo(name = "track_cnt") var trackCnt: Int,
-    @ColumnInfo(name = "artist_id") var artistId: Long
+    @ColumnInfo(name = "artist_id") var artistId: Long,
+    @ColumnInfo(name = "date_added") var dateAdded: Int,
 ) : ListItem(), Comparable<Album> {
     companion object {
         var sorting = 0
@@ -38,6 +40,13 @@ data class Album(
                     artist == MediaStore.UNKNOWN_STRING && other.artist != MediaStore.UNKNOWN_STRING -> 1
                     artist != MediaStore.UNKNOWN_STRING && other.artist == MediaStore.UNKNOWN_STRING -> -1
                     else -> AlphanumericComparator().compare(artist.lowercase(), other.artist.lowercase())
+                }
+            }
+            sorting and PLAYER_SORT_BY_DATE_ADDED != 0 -> {
+                when {
+                    dateAdded == 0 && other.dateAdded != 0 -> -1
+                    dateAdded != 0 && other.dateAdded == 0 -> 1
+                    else -> dateAdded.compareTo(other.dateAdded)
                 }
             }
             else -> year.compareTo(other.year)

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/models/Track.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/models/Track.kt
@@ -31,6 +31,7 @@ data class Track(
     @ColumnInfo(name = "album_id") var albumId: Long,
     @ColumnInfo(name = "artist_id") var artistId: Long,
     @ColumnInfo(name = "year") var year: Int,
+    @ColumnInfo(name = "date_added") var dateAdded: Int,
     @ColumnInfo(name = "order_in_playlist") var orderInPlaylist: Int,
     @ColumnInfo(name = "flags") var flags: Int = 0
 ) : Serializable, Comparable<Track>, ListItem() {
@@ -61,6 +62,13 @@ data class Track(
                     trackId == -1 && other.trackId != -1 -> 1
                     trackId != -1 && other.trackId == -1 -> -1
                     else -> AlphanumericComparator().compare(trackId.toString(), other.trackId.toString())
+                }
+            }
+            sorting and PLAYER_SORT_BY_DATE_ADDED != 0 -> {
+                when {
+                    dateAdded == 0 && other.dateAdded != 0 -> -1
+                    dateAdded != 0 && other.dateAdded == 0 -> 1
+                    else -> dateAdded.compareTo(other.dateAdded)
                 }
             }
             sorting and PLAYER_SORT_BY_CUSTOM != 0 -> {


### PR DESCRIPTION
Closes https://github.com/SimpleMobileTools/Simple-Music-Player/issues/254

### Changes:
 - Add sorting by Date added, works exactly the same way as any other sorting rules. Only tracks and albums have this sorting option because an artist can have multiple albums added at a different time (plus media store doesn't provide this info for albums and artists, only tracks. I added it for albums anyway).
 - Fix a minor glitch with newly set sorting getting reset when reopening the fragment