### PR TITLE
Avoid triggering `onTrackEnded()` unnecessarily

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/MultiPlayer.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/MultiPlayer.kt
@@ -40,13 +40,17 @@ class MultiPlayer(private val app: Application, private val callbacks: PlaybackC
             }
 
             AudioManager.AUDIOFOCUS_LOSS -> {
-                pause()
+                if (isPlaying()) {
+                    pause()
+                }
                 callbacks.onPlayStateChanged()
             }
 
             AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> {
                 val wasPlaying = isPlaying()
-                pause()
+                if (wasPlaying) {
+                    pause()
+                }
                 callbacks.onPlayStateChanged()
                 isPausedByTransientLossOfFocus = wasPlaying
             }


### PR DESCRIPTION
Closes https://github.com/SimpleMobileTools/Simple-Music-Player/issues/560

**Why it happened:** Calling pause on a paused media player triggers `onCompletion()` which in turn triggers MusicService's callback to set up the next track.