### PR TITLE
Crash fixes and improvements

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/MultiPlayer.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/MultiPlayer.kt
@@ -40,17 +40,13 @@ class MultiPlayer(private val app: Application, private val callbacks: PlaybackC
             }
 
             AudioManager.AUDIOFOCUS_LOSS -> {
-                if (isPlaying()) {
-                    pause()
-                }
+                pause()
                 callbacks.onPlayStateChanged()
             }
 
             AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> {
                 val wasPlaying = isPlaying()
-                if (wasPlaying) {
-                    pause()
-                }
+                pause()
                 callbacks.onPlayStateChanged()
                 isPausedByTransientLossOfFocus = wasPlaying
             }
@@ -142,6 +138,10 @@ class MultiPlayer(private val app: Application, private val callbacks: PlaybackC
     }
 
     fun pause(): Boolean {
+        if (!isPlaying()) {
+            return false
+        }
+
         unregisterBecomingNoisyReceiver()
         return try {
             mCurrentMediaPlayer.pause()

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/SimpleMediaScanner.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/SimpleMediaScanner.kt
@@ -211,25 +211,27 @@ class SimpleMediaScanner(private val context: Application) {
             val title = cursor.getStringValue(Audio.Media.TITLE)
             val duration = cursor.getIntValue(Audio.Media.DURATION) / 1000
             val trackId = cursor.getIntValue(Audio.Media.TRACK) % 1000
-            val path = cursor.getStringValue(Audio.Media.DATA)
+            val path = cursor.getStringValue(Audio.Media.DATA).orEmpty()
             val artist = cursor.getStringValue(Audio.Media.ARTIST) ?: MediaStore.UNKNOWN_STRING
-            val album = cursor.getStringValue(Audio.Media.ALBUM)
-            val albumId = cursor.getLongValue(Audio.Media.ALBUM_ID)
-            val artistId = cursor.getLongValue(Audio.Media.ARTIST_ID)
-            val year = cursor.getIntValue(Audio.Media.YEAR)
-            val dateAdded = cursor.getIntValue(Audio.Media.DATE_ADDED)
             val folderName = if (isQPlus()) {
                 cursor.getStringValue(Audio.Media.BUCKET_DISPLAY_NAME) ?: MediaStore.UNKNOWN_STRING
             } else {
                 ""
             }
 
+            val album = cursor.getStringValue(Audio.Media.ALBUM) ?: folderName
+            val albumId = cursor.getLongValue(Audio.Media.ALBUM_ID)
+            val artistId = cursor.getLongValue(Audio.Media.ARTIST_ID)
+            val year = cursor.getIntValue(Audio.Media.YEAR)
+            val dateAdded = cursor.getIntValue(Audio.Media.DATE_ADDED)
             val coverUri = ContentUris.withAppendedId(artworkUri, albumId)
             val coverArt = coverUri.toString()
 
-            val track = Track(0, id, title, artist, path, duration, album, coverArt, 0, trackId, folderName, albumId, artistId, year, dateAdded, 0)
-            track.title = track.getProperTitle(showFilename)
-            tracks.add(track)
+            if (!title.isNullOrEmpty()) {
+                val track = Track(0, id, title, artist, path, duration, album, coverArt, 0, trackId, folderName, albumId, artistId, year, dateAdded, 0)
+                track.title = track.getProperTitle(showFilename)
+                tracks.add(track)
+            }
         }
 
         return tracks
@@ -277,7 +279,7 @@ class SimpleMediaScanner(private val context: Application) {
         context.queryCursor(uri, projection.toTypedArray(), null, null, showErrors = true) { cursor ->
             val id = cursor.getLongValue(Audio.Albums._ID)
             val artistName = cursor.getStringValue(Audio.Albums.ARTIST) ?: MediaStore.UNKNOWN_STRING
-            val title = cursor.getStringValue(Audio.Albums.ALBUM)
+            val title = cursor.getStringValue(Audio.Albums.ALBUM) ?: MediaStore.UNKNOWN_STRING
             val coverArt = ContentUris.withAppendedId(artworkUri, id).toString()
             val year = cursor.getIntValue(Audio.Albums.FIRST_YEAR)
             val trackCnt = cursor.getIntValue(Audio.Albums.NUMBER_OF_SONGS)

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/SimpleMediaScanner.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/SimpleMediaScanner.kt
@@ -60,8 +60,10 @@ class SimpleMediaScanner(private val context: Application) {
         ensureBackgroundThread {
             try {
                 scanMediaStore()
-                onScanComplete?.invoke(false)
-                scanFilesManually()
+                if (isQPlus()) {
+                    onScanComplete?.invoke(false)
+                    scanFilesManually()
+                }
 
                 cleanupDatabase()
                 onScanComplete?.invoke(true)

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/SimpleMediaScanner.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/SimpleMediaScanner.kt
@@ -359,7 +359,7 @@ class SimpleMediaScanner(private val context: Application) {
             }
 
             if (title.isNotEmpty()) {
-                val track = Track(0, id, title, artist, path, duration, album, "", 0, trackId, folderName, 0, 0, year, dateAdded, FLAG_MANUAL_CACHE)
+                val track = Track(0, id, title, artist, path, duration, album, "", 0, trackId, folderName, 0, 0, year, dateAdded, 0, FLAG_MANUAL_CACHE)
                 // use hashCode() as id for tracking purposes, there's a very slim chance of collision
                 track.mediaStoreId = track.hashCode().toLong()
                 tracks.add(track)


### PR DESCRIPTION
### Changes:
 - Fix crash due to null albums https://github.com/SimpleMobileTools/Simple-Music-Player/issues/566
 - Disable manual scanning on Android 9 and below to avoid a native platform crash on some of the devices.
 - Use the proper flag for manually scanned tracks (I broke it in https://github.com/SimpleMobileTools/Simple-Music-Player/pull/563)
 - Always check `isPlaying()` before calling `pause()`to avoid any more cases like https://github.com/SimpleMobileTools/Simple-Music-Player/issues/560