### PR TITLE
Replace gapless playback with skip silence

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/activities/SettingsActivity.kt
@@ -44,7 +44,7 @@ class SettingsActivity : SimpleControllerActivity() {
         setupManageShownTabs()
         setupSwapPrevNext()
         setupReplaceTitle()
-        setupGaplessPlayback()
+        setupSkipSilence()
         updateTextColors(settings_nested_scrollview)
 
         arrayOf(settings_color_customization_section_label, settings_general_settings_label, settings_playback_section_label).forEach {
@@ -146,11 +146,11 @@ class SettingsActivity : SimpleControllerActivity() {
         }
     }
 
-    private fun setupGaplessPlayback() {
-        settings_gapless_playback.isChecked = config.gaplessPlayback
-        settings_gapless_playback_holder.setOnClickListener {
-            settings_gapless_playback.toggle()
-            config.gaplessPlayback = settings_gapless_playback.isChecked
+    private fun setupSkipSilence() {
+        settings_skip_silence.isChecked = config.skipSilence
+        settings_skip_silence_holder.setOnClickListener {
+            settings_skip_silence.toggle()
+            config.skipSilence = settings_skip_silence.isChecked
             withPlayer {
                 sendCommand(CustomCommands.TOGGLE_SKIP_SILENCE)
             }

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/Config.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/Config.kt
@@ -2,7 +2,7 @@ package com.simplemobiletools.musicplayer.helpers
 
 import android.content.Context
 import com.simplemobiletools.commons.helpers.BaseConfig
-import java.util.*
+import java.util.Arrays
 
 class Config(context: Context) : BaseConfig(context) {
     companion object {
@@ -139,7 +139,7 @@ class Config(context: Context) : BaseConfig(context) {
         excludedFolders = currExcludedFolders
     }
 
-    var gaplessPlayback: Boolean
-        get() = prefs.getBoolean(GAPLESS_PLAYBACK, false)
-        set(gaplessPlayback) = prefs.edit().putBoolean(GAPLESS_PLAYBACK, gaplessPlayback).apply()
+    var skipSilence: Boolean
+        get() = prefs.getBoolean(SKIP_SILENCE, false)
+        set(skipSilence) = prefs.edit().putBoolean(SKIP_SILENCE, skipSilence).apply()
 }

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/Constants.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/Constants.kt
@@ -63,7 +63,7 @@ const val TRACKS_REMOVED_FROM_ALL_TRACKS_PLAYLIST = "tracks_removed_from_all_tra
 const val LAST_EXPORT_PATH = "last_export_path"
 const val EXCLUDED_FOLDERS = "excluded_folders"
 const val SORT_PLAYLIST_PREFIX = "sort_playlist_"
-const val GAPLESS_PLAYBACK = "gapless_playback"
+const val SKIP_SILENCE = "skip_silence"
 
 const val SEEK_INTERVAL_MS = 10000L
 const val SEEK_INTERVAL_S = 10

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/playback/MediaSessionCallback.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/playback/MediaSessionCallback.kt
@@ -71,7 +71,7 @@ internal fun PlaybackService.getMediaSessionCallback() = object : MediaLibrarySe
             CustomCommands.CLOSE_PLAYER -> stopService()
             CustomCommands.RELOAD_CONTENT -> reloadContent()
             CustomCommands.TOGGLE_SLEEP_TIMER -> toggleSleepTimer()
-            CustomCommands.TOGGLE_SKIP_SILENCE -> player.setSkipSilence(config.gaplessPlayback)
+            CustomCommands.TOGGLE_SKIP_SILENCE -> player.setSkipSilence(config.skipSilence)
             CustomCommands.SET_SHUFFLE_ORDER -> setShuffleOrder(args)
             CustomCommands.SET_NEXT_ITEM -> setNextItem(args)
         }

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/playback/PlaybackService.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/playback/PlaybackService.kt
@@ -32,7 +32,7 @@ class PlaybackService : MediaLibraryService(), MediaSessionService.Listener {
     override fun onCreate() {
         super.onCreate()
         setListener(this)
-        initializeSessionAndPlayer(handleAudioFocus = true, handleAudioBecomingNoisy = true, skipSilence = config.gaplessPlayback)
+        initializeSessionAndPlayer(handleAudioFocus = true, handleAudioBecomingNoisy = true, skipSilence = config.skipSilence)
         initializeLibrary()
     }
 

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -213,17 +213,17 @@
                 android:text="@string/audio" />
 
             <RelativeLayout
-                android:id="@+id/settings_gapless_playback_holder"
+                android:id="@+id/settings_skip_silence_holder"
                 style="@style/SettingsHolderCheckboxStyle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
 
                 <com.simplemobiletools.commons.views.MyAppCompatCheckbox
-                    android:id="@+id/settings_gapless_playback"
+                    android:id="@+id/settings_skip_silence"
                     style="@style/SettingsCheckboxStyle"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@string/gapless_playback" />
+                    android:text="@string/skip_silence" />
 
             </RelativeLayout>
         </LinearLayout>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -92,7 +92,7 @@
     <string name="equalizer">المعادل(Equalizer)</string>
     <string name="swap_prev_next">تبديل أزرار السابق/التالي لسماعة الرأس</string>
     <string name="exclude_folder_description">إذا استبعدت مجلدا، فسيقوم ذلك على منع عرض جميع الملفات الصوتية فيه. لن تتأثر الملفات المضافة يدويا إلى قوائم التشغيل.</string>
-    <string name="gapless_playback">تشغيل بدون فجوات</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">إعادة فحص الوسائط</string>
     <!-- FAQ -->
     <string name="faq_1_title">كيف يمكنني التقدم أو الرجوع في الأغاني؟</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -84,7 +84,7 @@
     <string name="equalizer">Qarışdırıcı</string>
     <string name="swap_prev_next">Swap previous/next headphone buttons</string>
     <string name="exclude_folder_description">Excluding a folder will prevent the displaying of all audio files within. Files manually added to playlists will not be affected.</string>
-    <string name="gapless_playback">Gapless playback</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Rescan media</string>
     <!-- FAQ -->
     <string name="faq_1_title">How can I fast-forward songs\?</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -88,7 +88,7 @@
     <string name="equalizer">Эквалайзер</string>
     <string name="swap_prev_next">Абмяняць прызначэнне кнопак навушнікаў \"Папярэдні\"/\"Наступны\"</string>
     <string name="exclude_folder_description">Выключэнне папкі прадухіліць адлюстраванне ўсіх аўдыяфайлаў у ёй. Файлы, дададзеныя ў спісы прайгравання ўручную, не будуць закрануты.</string>
-    <string name="gapless_playback">Прайграванне без паўз</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Rescan media</string>
     <!-- FAQ -->
     <string name="faq_1_title">Як змяніць пазіцыю прайгравання кампазіцыі\?</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -84,7 +84,7 @@
     <string name="equalizer">Еквалайзер</string>
     <string name="swap_prev_next">Размяна на бутоните за предишно/следващо на слушалките</string>
     <string name="exclude_folder_description">Excluding a folder will prevent the displaying of all audio files within. Files manually added to playlists will not be affected.</string>
-    <string name="gapless_playback">Gapless playback</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Rescan media</string>
     <!-- FAQ -->
     <string name="faq_1_title">Как мога да превъртам песни\?</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -84,7 +84,7 @@
     <string name="equalizer">Equalitzador</string>
     <string name="swap_prev_next">Intercanvia els botons anterior/següent dels auriculars</string>
     <string name="exclude_folder_description">L\'exclusió d\'una carpeta impedirà que es mostrin tots els seus fitxers d\'àudio. Els fitxers afegits manualment a les llistes de reproducció no es veuran afectats.</string>
-    <string name="gapless_playback">Reproducció sense buits</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Torna a explorar els fitxers multimèdia</string>
     <!-- FAQ -->
     <string name="faq_1_title">Com puc avançar ràpidament les cançons\?</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -86,7 +86,7 @@
     <string name="equalizer">Ekvalizér</string>
     <string name="swap_prev_next">Zaměnit tlačítka sluchátek pro předchozí/následující skladbu</string>
     <string name="exclude_folder_description">Vyloučením složky zabráníte zobrazení všech zvukových souborů v ní. Soubory ručně přidané do seznamů skladeb nebudou ovlivněny.</string>
-    <string name="gapless_playback">Přehrávání bez mezer</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Rescan media</string>
     <!-- FAQ -->
     <string name="faq_1_title">Jak mohu rychle posunout skladbu vpřed\?</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -84,7 +84,7 @@
     <string name="equalizer">Equalizer</string>
     <string name="swap_prev_next">Ombyt forrige/næste hovedtelefonknapper</string>
     <string name="exclude_folder_description">Excluding a folder will prevent the displaying of all audio files within. Files manually added to playlists will not be affected.</string>
-    <string name="gapless_playback">Gapless playback</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Rescan media</string>
     <!-- FAQ -->
     <string name="faq_1_title">Hvordan kan jeg spole frem i sange\?</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -84,7 +84,7 @@
     <string name="equalizer">Equalizer</string>
     <string name="swap_prev_next">Vertausche die Kopfhörerknöpfe Vorheriger/Nächster Titel</string>
     <string name="exclude_folder_description">Das Ausschließen eines Ordner verhindert die Anzeige aller darin enthaltenen Audiodateien. Dateien, die manuell zu Wiedergabelisten hinzugefügt wurden, sind davon nicht betroffen.</string>
-    <string name="gapless_playback">Lückenlose Wiedergabe</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Medien erneut einlesen</string>
     <!-- FAQ -->
     <string name="faq_1_title">Wie kann ich Lieder vor- oder zurückspulen\?</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -84,7 +84,7 @@
     <string name="equalizer">Ισοσταθμιστής</string>
     <string name="swap_prev_next">Εναλλαγή κουμπιών ακουστικών Πίσω/Εμπρός</string>
     <string name="exclude_folder_description">Η Εξαίρεση ενός φακέλου θα αποτρέψει την εμφάνιση όλων των αρχείων ήχου εντός του φακέλου. Τα αρχεία που προστίθενται χειροκίνητα σε λίστες αναπαραγωγής δεν θα επηρεαστούν.</string>
-    <string name="gapless_playback">Αναπαραγωγή χωρίς κενά</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Επανασάρωση πολυμέσων</string>
     <!-- FAQ -->
     <string name="faq_1_title">Πώς μπορώ να προωθήσω γρήγορα τα τραγούδια;</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -84,7 +84,7 @@
     <string name="equalizer">Equalizer</string>
     <string name="swap_prev_next">Swap previous/next headphone buttons</string>
     <string name="exclude_folder_description">Excluding a folder will prevent the displaying of all audio files within. Files manually added to playlists will not be affected.</string>
-    <string name="gapless_playback">Gapless playback</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Rescan media</string>
     <!-- FAQ -->
     <string name="faq_1_title">How can I fast-forward songs\?</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -86,7 +86,7 @@
     <string name="equalizer">Ecualizador</string>
     <string name="swap_prev_next">Intercambiar botones de anterior/siguiente de los audífonos</string>
     <string name="exclude_folder_description">Excluir una carpeta impedirá que se muestren todos los archivos de audio que contiene. Los archivos agregados manualmente a las listas de reproducción no se verán afectados.</string>
-    <string name="gapless_playback">Reproducción continua</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Rescan media</string>
     <!-- FAQ -->
     <string name="faq_1_title">¿Cómo puedo avanzar en las canciones\?</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -84,7 +84,7 @@
     <string name="equalizer">Ekvalaiser</string>
     <string name="swap_prev_next">Vaheta kõrvaklappide eelmine/järgmine nupud</string>
     <string name="exclude_folder_description">Kausta välistamine keelab ka seal asuvate helifailide kuvamise. Käsitsi esitusloendisse lisatud failid jäävad kasutusele.</string>
-    <string name="gapless_playback">Lünkadeta taasesitus</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Tee meediakogu uus täisanalüüs</string>
     <!-- FAQ -->
     <string name="faq_1_title">Kuidas ma saan palasid kiiresti edasi kerida\?</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -84,7 +84,7 @@
     <string name="equalizer">Ekualizadorea</string>
     <string name="swap_prev_next">Trukatu aurreko/hurrengo entzungailuen botoiak</string>
     <string name="exclude_folder_description">Karpeta bat baztertzeak barruan dauden audio-fitxategi guztiak bistaratzea eragotziko du. Erreprodukzio-zerrendetan eskuz gehitutako fitxategiek ez dute eraginik izango.</string>
-    <string name="gapless_playback">Erreprodukzio jarraia</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Rescan media</string>
     <!-- FAQ -->
     <string name="faq_1_title">Nola aurreratu ditzaket azkar abestiak\?</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -84,7 +84,7 @@
     <string name="equalizer">اکولایزر</string>
     <string name="swap_prev_next">تغییر دکمه های قبلی و بعدی هدفون</string>
     <string name="exclude_folder_description">Excluding a folder will prevent the displaying of all audio files within. Files manually added to playlists will not be affected.</string>
-    <string name="gapless_playback">Gapless playback</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Rescan media</string>
     <!-- FAQ -->
     <string name="faq_1_title">چطور می توانم آهنگ ها را سریع ارسال کنم؟</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -84,7 +84,7 @@
     <string name="equalizer">Taajuuskorjain</string>
     <string name="swap_prev_next">Vaihda edellinen/seuraava kuulokepainikkeet</string>
     <string name="exclude_folder_description">Kansion poistaminen estää kaikkien kansiossa olevien äänitiedostojen näyttämisen. Tämä ei vaikuta soittolistoihin manuaalisesti lisättyihin tiedostoihin.</string>
-    <string name="gapless_playback">Gapless playback</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Rescan media</string>
     <!-- FAQ -->
     <string name="faq_1_title">Kuinka voin kelata kappaleita eteenpäin\?</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -86,7 +86,7 @@
     <string name="equalizer">Égaliseur</string>
     <string name="swap_prev_next">Remplacer les boutons des écouteurs précédents/suivants</string>
     <string name="exclude_folder_description">L\'exclusion d\'un dossier empêchera l\'affichage de tous les fichiers audio qu\'il contient. Les fichiers ajoutés manuellement aux listes de lecture ne seront pas affectés.</string>
-    <string name="gapless_playback">Lecture sans décalage</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Rescanner le média</string>
     <!-- FAQ -->
     <string name="faq_1_title">Comment puis-je faire avancer rapidement les chansons \?</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -84,7 +84,7 @@
     <string name="equalizer">Ecualizador</string>
     <string name="swap_prev_next">Intercambiar os botóns anterior/posterior dos auriculares</string>
     <string name="exclude_folder_description">A exclusión dun cartafol impedirá que se mostren todolos ficheiros de audio que hai. Os ficheiros engadidos manualmente ás listas de reprodución non se verán afectados.</string>
-    <string name="gapless_playback">Gapless playback</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Rescan media</string>
     <!-- FAQ -->
     <string name="faq_1_title">Como podo avanzar rapidamente as cancións\?</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -86,7 +86,7 @@
     <string name="equalizer">Ekvilizator</string>
     <string name="swap_prev_next">Zamijeni gumbe prethodne/sljedeća slušalice</string>
     <string name="exclude_folder_description">Isključivanje mape spriječit će prikazivanje svih audio datoteka u njoj. To neće utjecati na datoteke koje su ručno dodane na popise za reprodukciju.</string>
-    <string name="gapless_playback">Reprodukcija bez prekida</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Rescan media</string>
     <!-- FAQ -->
     <string name="faq_1_title">Kako mogu premotati pjesme\?</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -84,7 +84,7 @@
     <string name="equalizer">Hangszínszabályzó</string>
     <string name="swap_prev_next">Fejhallgató számváltó gombjainak felcserélése</string>
     <string name="exclude_folder_description">A mappa kihagyása megakadályozza a benne lévő összes hangfájl megjelenítését. A lejátszási listákhoz kézileg hozzáadott fájlokat ez nem érinti.</string>
-    <string name="gapless_playback">Hézagmentes lejátszás</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Média újraolvasása</string>
     <!-- FAQ -->
     <string name="faq_1_title">Hogy tudom a számot előre tekerni\?</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -82,7 +82,7 @@
     <string name="equalizer">Ekualiser</string>
     <string name="swap_prev_next">Tukar tombol pemilih lagu sebelumnya/berikutnya pada headphone</string>
     <string name="exclude_folder_description">Tidak menyertakan folder akan mencegah penampilan semua berkas audio yang di dalamnya. Berkas yang ditambahkan secara manual ke daftar putar tidak berpengaruh.</string>
-    <string name="gapless_playback">Gapless playback</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Rescan media</string>
     <!-- FAQ -->
     <string name="faq_1_title">Bagaimana saya memajukan lagu\?</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -84,7 +84,7 @@
     <string name="equalizer">Tónjafnari</string>
     <string name="swap_prev_next">Skiptu um fyrra/næsta heyrnartólshnappa</string>
     <string name="exclude_folder_description">Að útiloka möppu kemur í veg fyrir birtingu allra hljóðskráa innan. Skrár sem bætt er handvirkt við lagalista verða ekki fyrir áhrifum.</string>
-    <string name="gapless_playback">Gapless playback</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Rescan media</string>
     <!-- FAQ -->
     <string name="faq_1_title">Hvernig get ég hraðspólað lög\?</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -86,7 +86,7 @@
     <string name="equalizer">Equalizzatore</string>
     <string name="swap_prev_next">Inverti i pulsanti successivo/precedente delle cuffiette</string>
     <string name="exclude_folder_description">L\'esclusione di una cartella impedisce la visualizzazione di tutti i file audio al suo interno. I file aggiunti manualmente alle playlist non saranno interessati.</string>
-    <string name="gapless_playback">Riproduzione senza intervallo</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Riscansiona il media</string>
     <!-- FAQ -->
     <string name="faq_1_title">Come posso avanzare rapidamente nei brani\?</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -88,7 +88,7 @@
     <string name="equalizer">שוין</string>
     <string name="swap_prev_next">החלף את לחצני האוזניות הקודמות/הבאות</string>
     <string name="exclude_folder_description">Excluding a folder will prevent the displaying of all audio files within. Files manually added to playlists will not be affected.</string>
-    <string name="gapless_playback">Gapless playback</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Rescan media</string>
     <!-- FAQ -->
     <string name="faq_1_title">איך אני יכול להריץ שירים קדימה\?</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -82,7 +82,7 @@
     <string name="equalizer">イコライザー</string>
     <string name="swap_prev_next">ヘッドフォンの 前へ/次へ ボタンを入れ替える</string>
     <string name="exclude_folder_description">フォルダを除外すると、フォルダ内のすべてのオーディオファイルが表示されなくなります。プレイリストに手動で追加したファイルは影響を受けません。</string>
-    <string name="gapless_playback">Gapless playback</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Rescan media</string>
     <!-- FAQ -->
     <string name="faq_1_title">曲を早送りするにはどうすればよいですか？</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -82,7 +82,7 @@
     <string name="equalizer">이퀄라이저</string>
     <string name="swap_prev_next">Swap previous/next headphone buttons</string>
     <string name="exclude_folder_description">Excluding a folder will prevent the displaying of all audio files within. Files manually added to playlists will not be affected.</string>
-    <string name="gapless_playback">Gapless playback</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Rescan media</string>
     <!-- FAQ -->
     <string name="faq_1_title">How can I fast-forward songs\?</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -86,7 +86,7 @@
     <string name="equalizer">Ekvalaizeris</string>
     <string name="swap_prev_next">Ankstesnių / vėlesnių ausinių mygtukų keitimas</string>
     <string name="exclude_folder_description">Excluding a folder will prevent the displaying of all audio files within. Files manually added to playlists will not be affected.</string>
-    <string name="gapless_playback">Gapless playback</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Rescan media</string>
     <!-- FAQ -->
     <string name="faq_1_title">Kaip greitai persukti dainas į priekį\?</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -84,7 +84,7 @@
     <string name="equalizer">സമകാരി</string>
     <string name="swap_prev_next">മുമ്പത്തെ/അടുത്ത ഹെഡ്‌ഫോൺ ബട്ടണുകൾ മാറ്റുക</string>
     <string name="exclude_folder_description">ഒരു ഫോൾഡർ ഒഴികെയുള്ള എല്ലാ ഓഡിയോ ഫയലുകളും പ്രദർശിപ്പിക്കുന്നത് തടയും. പ്ലേലിസ്റ്റുകളിലേക്ക് സ്വമേധയാ ചേർത്ത ഫയലുകളെ ബാധിക്കില്ല.</string>
-    <string name="gapless_playback">Gapless playback</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Rescan media</string>
     <!-- FAQ -->
     <string name="faq_1_title">എനിക്ക് എങ്ങനെ പാട്ടുകൾ വേഗത്തിൽ മുന്നോട്ട് ചെയ്യാം\?</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -82,7 +82,7 @@
     <string name="equalizer">Equalizer</string>
     <string name="swap_prev_next">Tukar butang fon kepala sebelumnya/seterusnya</string>
     <string name="exclude_folder_description">Excluding a folder will prevent the displaying of all audio files within. Files manually added to playlists will not be affected.</string>
-    <string name="gapless_playback">Gapless playback</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Rescan media</string>
     <!-- FAQ -->
     <string name="faq_1_title">Bagaimana saya boleh meneruskan lagu\?</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -84,7 +84,7 @@
     <string name="equalizer">Tonekontroll</string>
     <string name="swap_prev_next">Bytt hodetelefonknapper for forrige/neste</string>
     <string name="exclude_folder_description">Excluding a folder will prevent the displaying of all audio files within. Files manually added to playlists will not be affected.</string>
-    <string name="gapless_playback">Gapless playback</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Rescan media</string>
     <!-- FAQ -->
     <string name="faq_1_title">Hvordan kan jeg spole fremover sanger\?</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -84,7 +84,7 @@
     <string name="equalizer">Equalizer</string>
     <string name="swap_prev_next">Knoppen Vorige/Volgende op koptelefoon omdraaien</string>
     <string name="exclude_folder_description">Het uitsluiten van een map zorgt ervoor dat alle geluidsbestanden in deze map worden genegeerd. Dit heeft geen gevolgen voor bestanden die handmatig zijn toegevoegd aan afspeellijsten.</string>
-    <string name="gapless_playback">Gapless afspelen</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Media doorzoeken</string>
     <!-- FAQ -->
     <string name="faq_1_title">Hoe kan ik een nummer vooruitspoelen\?</string>

--- a/app/src/main/res/values-nn/strings.xml
+++ b/app/src/main/res/values-nn/strings.xml
@@ -84,7 +84,7 @@
     <string name="equalizer">Tonejamnar</string>
     <string name="swap_prev_next">Byt om på høyretelefonknappane for førre/neste</string>
     <string name="exclude_folder_description">Steng ut ei mappa for å hindre hennar ljodfiler ifrå å verta viste. Filer lagde til i spelelister for hand, vert ikkje påverka.</string>
-    <string name="gapless_playback">Gapless playback</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Rescan media</string>
     <!-- FAQ -->
     <string name="faq_1_title">Brigde av snøggleiken til låter</string>

--- a/app/src/main/res/values-pa-rPK/strings.xml
+++ b/app/src/main/res/values-pa-rPK/strings.xml
@@ -84,7 +84,7 @@
     <string name="equalizer">برابری کرن والا</string>
     <string name="swap_prev_next">ہیڈفون دے پچھلے بٹن تے اگے بٹن سویپ کرو</string>
     <string name="exclude_folder_description">Excluding a folder will prevent the displaying of all audio files within. Files manually added to playlists will not be affected.</string>
-    <string name="gapless_playback">Gapless playback</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Rescan media</string>
     <!-- FAQ -->
     <string name="faq_1_title">میں گیتاں نوں کیویں تیزی نال اگے ودھا سکدا ہاں؟</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -88,7 +88,7 @@
     <string name="equalizer">Korektor</string>
     <string name="swap_prev_next">Zamień przyciski słuchawek poprzedni/następny</string>
     <string name="exclude_folder_description">Wykluczenie folderu uniemożliwi wyświetlanie wszystkich znajdujących się w nim plików audio. Nie wpłynie to na pliki ręcznie dodane do playlist.</string>
-    <string name="gapless_playback">Odtwarzanie bez przerw</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Przeskanuj ponownie multimedia</string>
     <!-- FAQ -->
     <string name="faq_1_title">Jak mogę przewijać utwory do przodu\?</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -84,7 +84,7 @@
     <string name="equalizer">Equalizador</string>
     <string name="swap_prev_next">Trocar os botões anterior/próximo do fone de ouvido</string>
     <string name="exclude_folder_description">A exclusão de uma pasta impedirá a exibição de todos os arquivos de áudio dentro dela. Os arquivos adicionados manualmente às listas de reprodução não serão afetados.</string>
-    <string name="gapless_playback">Gapless playback</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Rescan media</string>
     <!-- FAQ -->
     <string name="faq_1_title">Como posso avançar músicas\?</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -86,7 +86,7 @@
     <string name="equalizer">Equalizador</string>
     <string name="swap_prev_next">Trocar de faixa com os botões do auricular</string>
     <string name="exclude_folder_description">Se excluir uma pasta, não conseguirá ver os ficheiros lá existentes. Os ficheiros adicionados manualmente a uma lista de reprodução não serão afetados.</string>
-    <string name="gapless_playback">Reprodução sem pausas</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Reanalisar dados</string>
     <!-- FAQ -->
     <string name="faq_1_title">Posso avançar/recuar rapidamente uma faixa\?</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -86,7 +86,7 @@
     <string name="equalizer">Egalizator</string>
     <string name="swap_prev_next">Inversaţi butoanele anterior/următor pentru căști</string>
     <string name="exclude_folder_description">Excluding a folder will prevent the displaying of all audio files within. Files manually added to playlists will not be affected.</string>
-    <string name="gapless_playback">Gapless playback</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Rescan media</string>
     <!-- FAQ -->
     <string name="faq_1_title">Cum pot să avansez rapid melodiile\?</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -88,7 +88,7 @@
     <string name="equalizer">Эквалайзер</string>
     <string name="swap_prev_next">Поменять местами кнопки \"Предыдущая\"/\"Следующая\" на гарнитуре</string>
     <string name="exclude_folder_description">Исключение папки предотвратит отображение всех аудиофайлов внутри неё. Файлы, добавленные вручную в списки воспроизведения, не будут затронуты.</string>
-    <string name="gapless_playback">Воспроизведение без пауз</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Пересканировать медиа</string>
     <!-- FAQ -->
     <string name="faq_1_title">Как я могу перемотать композицию\?</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -86,7 +86,7 @@
     <string name="equalizer">Ekvalizér</string>
     <string name="swap_prev_next">Vymeniť slúchadlové tlačidlá pre ďalšiu/predošlú skladbu</string>
     <string name="exclude_folder_description">Vylúčenie priečinka spôsobí ukrytie daných audio súborov. Súbory ručne pridané do playlistov nebudú ovplyvnené.</string>
-    <string name="gapless_playback">Prehrávanie bez medzier</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Preskenovať médiá</string>
     <!-- FAQ -->
     <string name="faq_1_title">Ako viem posunúť skladbu vpred\?</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -88,7 +88,7 @@
     <string name="equalizer">Izenačevalnik</string>
     <string name="swap_prev_next">Zamenjava prejšnjih/naslednjih gumbov za slušalke</string>
     <string name="exclude_folder_description">Če izvzamete mapo, boste preprečili prikazovanje vseh zvočnih datotek v njej. To ne bo vplivalo na ročno dodane datoteke v sezname predvajanja.</string>
-    <string name="gapless_playback">Gapless playback</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Rescan media</string>
     <!-- FAQ -->
     <string name="faq_1_title">Kako lahko pesmi prestavim naprej\?</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -86,7 +86,7 @@
     <string name="equalizer">Еквилајзер</string>
     <string name="swap_prev_next">Замените претходне/следеће дугме на слушалицама</string>
     <string name="exclude_folder_description">Изузимање фасцикле ће спречити приказивање свих аудио датотека у њему. То неће утицати на датотеке које су ручно додате на плејлисте.</string>
-    <string name="gapless_playback">Gapless playback</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Rescan media</string>
     <!-- FAQ -->
     <string name="faq_1_title">Како могу да премотам песме унапред\?</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -84,7 +84,7 @@
     <string name="equalizer">Frekvenskorrigerare</string>
     <string name="swap_prev_next">Växla hörlurars föregående- och nästaknappar</string>
     <string name="exclude_folder_description">När du utesluter en mapp hindrar det alla ljudfiler i mappen från att visas. Filer som har lagts till i spellistor manuellt påverkas inte.</string>
-    <string name="gapless_playback">Uppspelning utan avbrott</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Skanna media igen</string>
     <!-- FAQ -->
     <string name="faq_1_title">Hur kan jag snabbspola låtar\?</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -82,7 +82,7 @@
     <string name="equalizer">Equalizer</string>
     <string name="swap_prev_next">Swap previous/next headphone buttons</string>
     <string name="exclude_folder_description">Excluding a folder will prevent the displaying of all audio files within. Files manually added to playlists will not be affected.</string>
-    <string name="gapless_playback">Gapless playback</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Rescan media</string>
     <!-- FAQ -->
     <string name="faq_1_title">How can I fast-forward songs\?</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -84,7 +84,7 @@
     <string name="equalizer">Ekolayzır</string>
     <string name="swap_prev_next">Önceki/sonraki kulaklık düğmelerini değiştir</string>
     <string name="exclude_folder_description">Bir klasörün hariç tutulması, içindeki tüm ses dosyalarının görüntülenmesini engelleyecektir. Çalma listelerine elle eklenen dosyalar etkilenmeyecektir.</string>
-    <string name="gapless_playback">Aralıksız oynatım</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Medyayı yeniden tara</string>
     <!-- FAQ -->
     <string name="faq_1_title">Şarkıları nasıl hızlıca ileri sarabilirim\?</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -88,7 +88,7 @@
     <string name="equalizer">Еквалайзер</string>
     <string name="swap_prev_next">Змінити призначення кнопок навушників Попередній/Наступний</string>
     <string name="exclude_folder_description">Виключення папки перешкоджатиме відображенню всіх аудіофайлів у ній. Файли, додані до списків відтворення вручну, не постраждають.</string>
-    <string name="gapless_playback">Відтворення без пауз</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Rescan media</string>
     <!-- FAQ -->
     <string name="faq_1_title">Як я можу змінити позицію відтворення композиції\?</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -82,7 +82,7 @@
     <string name="equalizer">均衡器</string>
     <string name="swap_prev_next">交换耳机上的上一首/下一首按钮</string>
     <string name="exclude_folder_description">排除一个文件夹将阻止显示其中所有的音频文件。手动添加到播放列表的文件不会受到影响。</string>
-    <string name="gapless_playback">无缝播放</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">重新扫描媒体</string>
     <!-- FAQ -->
     <string name="faq_1_title">我如何快进歌曲？</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -82,7 +82,7 @@
     <string name="equalizer">等化器</string>
     <string name="swap_prev_next">交換耳機按鈕的 上一首/下一首</string>
     <string name="exclude_folder_description">Excluding a folder will prevent the displaying of all audio files within. Files manually added to playlists will not be affected.</string>
-    <string name="gapless_playback">Gapless playback</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Rescan media</string>
     <!-- FAQ -->
     <string name="faq_1_title">要怎麼快轉歌曲？</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,7 +84,7 @@
     <string name="equalizer">Equalizer</string>
     <string name="swap_prev_next">Swap previous/next headphone buttons</string>
     <string name="exclude_folder_description">Excluding a folder will prevent the displaying of all audio files within. Files manually added to playlists will not be affected.</string>
-    <string name="gapless_playback">Gapless playback</string>
+    <string name="skip_silence">Skip silence</string>
     <string name="rescan_media">Rescan media</string>
     <!-- FAQ -->
     <string name="faq_1_title">How can I fast-forward songs?</string>


### PR DESCRIPTION
Since exoplayer transitions between media items as seamlessly as possible, we don't need a switch for it (it works as well as the previous `MediaPlayer.setNextMediaPlayer` implementation). The skip silence feature **trims any silence in the audio stream**, not just at the start/end hence putting gapless playback there is a little misleading. 

<img src="https://github.com/SimpleMobileTools/Simple-Music-Player/assets/36371707/9a5aab39-d009-4425-bbc1-c81b5abdd35d" width=264 />


**If we don't want to add such a feature, we can remove the preference and category.**

**Sidenote:** True gapless playback (absolutely zero gaps) is possible in exoplayer but we don't really want to complicate things using concatenated media sources.
