### PR TITLE
Fix playlist deletion

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/adapters/AlbumsTracksAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/adapters/AlbumsTracksAdapter.kt
@@ -72,6 +72,7 @@ class AlbumsTracksAdapter(
     override fun prepareActionMode(menu: Menu) {
         menu.apply {
             findItem(R.id.cab_play_next).isVisible = shouldShowPlayNext()
+            findItem(R.id.cab_rename).isVisible = shouldShowRename()
         }
     }
 


### PR DESCRIPTION
### Changes:
 - Fix deleting playlists (I broke it during media3 changes)
 - Use the newer createDeleteRequest delete method instead of relying on the old SAF-based method.
 - Hide rename options at albums