### PR TITLE
Fix shuffle and other issues

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/playback/player/AudioOnlyRenderersFactory.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/playback/player/AudioOnlyRenderersFactory.kt
@@ -22,7 +22,7 @@ private const val SKIP_SILENCE_THRESHOLD_LEVEL = 16.toShort()
 @UnstableApi
 class AudioOnlyRenderersFactory(context: Context) : DefaultRenderersFactory(context) {
 
-    override fun buildAudioSink(context: Context, enableFloatOutput: Boolean, enableAudioTrackPlaybackParams: Boolean): AudioSink {
+    override fun buildAudioSink(context: Context, enableFloatOutput: Boolean, enableAudioTrackPlaybackParams: Boolean, enableOffload: Boolean): AudioSink? {
         val silenceSkippingAudioProcessor = SilenceSkippingAudioProcessor(
             SKIP_SILENCE_MINIMUM_DURATION_US,
             DEFAULT_PADDING_SILENCE_US,
@@ -32,6 +32,13 @@ class AudioOnlyRenderersFactory(context: Context) : DefaultRenderersFactory(cont
         return DefaultAudioSink.Builder(context)
             .setEnableFloatOutput(enableFloatOutput)
             .setEnableAudioTrackPlaybackParams(enableAudioTrackPlaybackParams)
+            .setOffloadMode(
+                if (enableOffload) {
+                    DefaultAudioSink.OFFLOAD_MODE_ENABLED_GAPLESS_REQUIRED
+                } else {
+                    DefaultAudioSink.OFFLOAD_MODE_DISABLED
+                }
+            )
             .setAudioProcessorChain(
                 DefaultAudioSink.DefaultAudioProcessorChain(
                     arrayOf(),

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/playback/player/Player.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/playback/player/Player.kt
@@ -64,7 +64,11 @@ private fun PlaybackService.initializePlayer(handleAudioFocus: Boolean, handleAu
                     .build(),
                 handleAudioFocus
             )
-            .setSkipSilenceEnabled(skipSilence)
+            .setSkipSilenceEnabled(
+                // TODO: Enable when https://github.com/androidx/media/issues/712 is resolved.
+                //  See https://github.com/SimpleMobileTools/Simple-Music-Player/issues/604
+                false //skipSilence
+            )
             .setSeekBackIncrementMs(SEEK_INTERVAL_MS)
             .setSeekForwardIncrementMs(SEEK_INTERVAL_MS)
             .setLooper(playerThread.looper)

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/playback/player/SimpleMusicPlayer.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/playback/player/SimpleMusicPlayer.kt
@@ -141,7 +141,7 @@ class SimpleMusicPlayer(private val exoPlayer: ExoPlayer) : ForwardingPlayer(exo
     private fun seekWithDelay() {
         seekJob?.cancel()
         seekJob = scope.launch {
-            delay(timeMillis = 400)
+            delay(timeMillis = 300)
             val seekCount = seekToNextCount - seekToPreviousCount
             if (seekCount != 0) {
                 seekByCount(seekCount)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ eventbus = "3.3.1"
 lottie = "6.1.0"
 m3uParser = "1.3.0"
 media = "1.6.0"
-media3 = "1.2.0-alpha02"
+media3 = "1.1.1"
 room = "2.5.2"
 #Simple Mobile Tools
 simple-commons = "6a7777d740"


### PR DESCRIPTION
### Changes:
- Downgrade media3 to 1.1.1. Although 1.2.0-alpha02 has some improvements, it crashes when the app is cold starting (e.g. force-stopped) from the background.
- Fix a seek next/previous issue when shuffle mode is enabled. Originally introduced in my previous PR: https://github.com/SimpleMobileTools/Simple-Music-Player/pull/615  
- Internally disable skip silence until https://github.com/androidx/media/issues/712 is resolved (this **won't** break seamless playback, https://github.com/SimpleMobileTools/Simple-Music-Player/issues/604)

I have reported the media3 crash on the media3 repo so it should only be updated once https://github.com/androidx/media/issues/733 is resolved.